### PR TITLE
add const qualification to ArrayView::operator=(T const & rhs )

### DIFF
--- a/src/src/ArrayView.hpp
+++ b/src/src/ArrayView.hpp
@@ -192,8 +192,10 @@ public:
    * @brief set all values of array to rhs
    * @param rhs value that array will be set to.
    */
+  template< typename U = T >
   inline LVARRAY_HOST_DEVICE CONSTEXPRFUNC
-  ArrayView & operator=( T const & rhs ) noexcept
+  typename std::enable_if< !(std::is_const<U>::value), ArrayView const & >::type
+  operator=( T const & rhs ) const noexcept
   {
     INDEX_TYPE const length = size();
     T* const data_ptr = data();


### PR DESCRIPTION
This is to allow the use of the `operator=` in the case of something like 
```
arrayView1d<real64> const & lhs = blahblahblah;
lhs = 0.0;
```

@corbett5 any objections?