### PR TITLE
Const-conversion for nested ArrayView

### DIFF
--- a/src/src/helpers.hpp
+++ b/src/src/helpers.hpp
@@ -301,23 +301,17 @@ template< typename T,
           typename INDEX_TYPE >
 struct to_arrayViewConst< Array< T, NDIM, INDEX_TYPE > >
 {
-  using type = ArrayView< T const, NDIM, INDEX_TYPE > const;
+  using type = ArrayView< typename to_arrayViewConst<T>::type const, NDIM, INDEX_TYPE > const;
 };
 
-/* Note this will only work when using ChaiVector as the DATA_VECTOR_TYPE. */
 template< typename T,
-          int NDIM1,
-          typename INDEX_TYPE1,
-          int NDIM0,
-          typename INDEX_TYPE0 >
-struct to_arrayViewConst< Array< Array< T, NDIM1, INDEX_TYPE1 >,
-                                 NDIM0,
-                                 INDEX_TYPE0 > >
+  int NDIM,
+  typename INDEX_TYPE >
+struct to_arrayViewConst< ArrayView< T, NDIM, INDEX_TYPE > >
 {
-  using type = ArrayView< typename to_arrayViewConst< Array< T, NDIM1, INDEX_TYPE1 > >::type,
-                          NDIM0,
-                          INDEX_TYPE0 > const;
+  using type = ArrayView< typename to_arrayViewConst<T>::type const, NDIM, INDEX_TYPE > const;
 };
+
 
 } /* namespace detail */
 


### PR DESCRIPTION
Motivations is as follows: starting from
```c++
Array< Array< ArrayView< T, N >, 1 >, 1 > data;
```
(this is an `ElementViewAccessor`), I want to get
```c++
ArrayView< ArrayView< ArrayView< T const, N > const, 1 > const, 1 > const & dataConstView = data.toViewConst();
// or ElementViewAccessor< ArrayView< T, N > >::asViewConst & dataConstView = data.toViewConst();
```
in order to use the latter in a kernel (ugly, but FV flux assembly needs to work across multiple regions/subregions).

Right now this won't work, since type recursion in `detail::to_arrayViewConst` does not drop into `ArrayView`s. With the change, it should traverse any mix of nested `Array` and `ArrayView` and apply the conversion throughout. It passes all unit tests. Any pitfalls?

(I did not touch the non-constifying version because I had no need to, but it could be changed in a similar fashion)