### PR TITLE
Kahan 2x2 determinant computation reduces numerical imprecision.

### DIFF
--- a/src/fixedSizeSquareMatrixOpsImpl.hpp
+++ b/src/fixedSizeSquareMatrixOpsImpl.hpp
@@ -89,17 +89,9 @@ struct SquareMatrixOps< 2 >
   {
     checkSizes< 2, 2 >( matrix );
 
-    // Aliases for matrix [[a, b],[c, d]] for improved readability
-    auto const & a = matrix[0][0];
-    auto const & b = matrix[0][1];
-    auto const & c = matrix[1][0];
-    auto const & d = matrix[1][1];
-
     // Using the more precise Kahan method to compute the 2x2 determinant.
-    auto const w = b * c;
-    auto const e = fma( -b, c, w );
-    auto const f = fma( a, d, -w );
-    return f + e;
+    auto const tmp = matrix[0][1] * matrix[1][0];
+    return math::fma( -matrix[0][1], matrix[1][0], tmp ) + math::fma( matrix[0][0], matrix[1][1], -tmp );
   }
 
   /**

--- a/src/fixedSizeSquareMatrixOpsImpl.hpp
+++ b/src/fixedSizeSquareMatrixOpsImpl.hpp
@@ -88,7 +88,18 @@ struct SquareMatrixOps< 2 >
   static auto determinant( MATRIX const & matrix )
   {
     checkSizes< 2, 2 >( matrix );
-    return matrix[ 0 ][ 0 ] * matrix[ 1 ][ 1 ] - matrix[ 0 ][ 1 ] * matrix[ 1 ][ 0 ];
+
+    // Aliases for matrix [[a, b],[c, d]] for improved readability
+    auto const & a = matrix[0][0];
+    auto const & b = matrix[0][1];
+    auto const & c = matrix[1][0];
+    auto const & d = matrix[1][1];
+
+    // Using the more precise Kahan method to compute the 2x2 determinant.
+    auto const w = b * c;
+    auto const e = fma( -b, c, w );
+    auto const f = fma( a, d, -w );
+    return f + e;
   }
 
   /**

--- a/src/math.hpp
+++ b/src/math.hpp
@@ -28,7 +28,7 @@ namespace LvArray
 {
 
 /**
- * @brief Contains protable wrappers around cmath functions and some cuda specific functions.
+ * @brief Contains portable wrappers around cmath functions and some cuda specific functions.
  */
 namespace math
 {
@@ -315,6 +315,46 @@ max( T const a, T const b )
 #else
   return std::max( a, b );
 #endif
+}
+
+/**
+ * @return Returns @p x * @p y + @p z.
+ * @tparam T A floating point type.
+ * @param x The first number.
+ * @param y The second number.
+ * @param z The third number.
+ * @note fma stands for fused multiply add.
+ *
+ * The function computes the result without losing precision in any intermediate result.
+ * Integer arguments cast to double.
+ * We want to avoid that by providing a version dedicated to integers.
+ */
+template< typename T >
+LVARRAY_HOST_DEVICE inline constexpr
+std::enable_if_t< std::is_floating_point< T >::value, T >
+fma( T const x, T const y, T const z )
+{
+#if defined(__CUDA_ARCH__)
+  return ::fma( x, y, z );
+#else
+  return std::fma( x, y, z );
+#endif
+}
+
+/**
+ * @return Returns @p x * @p y + @p z.
+ * @tparam T A floating point type.
+ * @param x The first number.
+ * @param y The second number.
+ * @param z The third number.
+ * @note This is a dummy implementation for integers (in order to not cast to doubles).
+ */
+template< typename T >
+LVARRAY_HOST_DEVICE inline constexpr
+std::enable_if_t< std::is_integral< T >::value, T >
+fma( T const x, T const y, T const z )
+{
+  return x * y + z;
 }
 
 #if defined( LVARRAY_USE_CUDA )


### PR DESCRIPTION
Related to issue https://github.com/GEOSX/GEOSX/issues/1440: some tests `testTensorOpsInverseTwoArgs` and `testTensorOpsInverseOneArg` are failing due to large numerical imprecision.

Using the Kahan method to compute 2x2 determinants brings more precision.
3x3 case still untouched.

Warning, I sometimes get compilation warnings like
```
../coreComponents/LvArray/unitTests/../src/fixedSizeSquareMatrixOpsImpl.hpp(100): warning: calling a constexpr __host__ function("fma") from a __host__ __device__ function("determinant") is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
```
which I find surprising since this `fma` function is supposed to be `device` friendly.
`fma` also [seems pretty standard](https://www.cplusplus.com/reference/cmath/fma/) so one should not need any fallback.
So I need to double-check.

Any opinion?