### PR TITLE
Add integerConversion to guard against integer truncation errors.

### DIFF
--- a/src/arrayManipulation.hpp
+++ b/src/arrayManipulation.hpp
@@ -297,7 +297,7 @@ void resize( T * const LVARRAY_RESTRICT ptr,
   {
     if( newSize - size > 0 )
     {
-      size_t const sizeDiff = integerConversion< size_t >( newSize - size );
+     std::size_t const sizeDiff = integerConversion< std::size_t >( newSize - size );
       std::memset( reinterpret_cast< void * >( ptr + size ), 0, ( sizeDiff ) * sizeof( T ) );
     }
   }

--- a/src/arrayManipulation.hpp
+++ b/src/arrayManipulation.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 // Source includes
+#include "limits.hpp"
 #include "Macros.hpp"
 #include "typeManipulation.hpp"
 
@@ -296,7 +297,8 @@ void resize( T * const LVARRAY_RESTRICT ptr,
   {
     if( newSize - size > 0 )
     {
-      std::memset( reinterpret_cast< void * >( ptr + size ), 0, ( newSize - size ) * sizeof( T ) );
+      size_t const sizeDiff = integerConversion<size_t>(newSize - size);
+      std::memset( reinterpret_cast< void * >( ptr + size ), 0, ( sizeDiff ) * sizeof( T ) );
     }
   }
   else

--- a/src/arrayManipulation.hpp
+++ b/src/arrayManipulation.hpp
@@ -297,7 +297,7 @@ void resize( T * const LVARRAY_RESTRICT ptr,
   {
     if( newSize - size > 0 )
     {
-      size_t const sizeDiff = integerConversion<size_t>(newSize - size);
+      size_t const sizeDiff = integerConversion< size_t >( newSize - size );
       std::memset( reinterpret_cast< void * >( ptr + size ), 0, ( sizeDiff ) * sizeof( T ) );
     }
   }


### PR DESCRIPTION
gcc was giving warnings:
```
In function 'void makeTetra(geosx::array2d<double>&, geosx::FaceManager::NodeMapType&, geosx::array1d<int>&, geosx::real64 (&)[3], geosx::real64&, geosx::real64 (&)[3], geosx::real64&, geosx::integer, geosx::arraySlice2d<double>&)':
[4044]()cc1plus: error: 'void* __builtin_memset(void*, int, long unsigned int)' specified size between 18446744065119617048 and 18446744073709551612 exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
[4045]()cc1plus: all warnings being treated as errors
```
which was due to some sort of possible conversion from `int` to `long unsigned int`. This avoids the possibility that `memset` is passed an `int` in place of an `long unsigned int`.