### PR TITLE
Add LVARRAY_ERROR_IF_PRINTF() macro to prinnt fancyer messages on errors

### DIFF
--- a/examples/exampleArrayOfSets.cpp
+++ b/examples/exampleArrayOfSets.cpp
@@ -59,8 +59,8 @@ TEST( ArrayOfSets, assimilate )
   arrayOfArrays.emplaceBack( 2, 1 );
 
   // Assimilate arrayOfArrays into arrayOfSets.
-  arrayOfSets.assimilate( std::move( arrayOfArrays ),
-                          LvArray::sortedArrayManipulation::Description::SORTED_UNIQUE );
+  arrayOfSets.assimilate< RAJA::loop_exec >( std::move( arrayOfArrays ),
+                                             LvArray::sortedArrayManipulation::Description::SORTED_UNIQUE );
 
   // After being assimilated arrayOfArrays is empty.
   EXPECT_EQ( arrayOfArrays.size(), 0 );
@@ -84,8 +84,8 @@ TEST( ArrayOfSets, assimilate )
   arrayOfArrays.emplaceBack( 1, 4 );
 
   // Assimilate the arrayOfArrays yet again.
-  arrayOfSets.assimilate( std::move( arrayOfArrays ),
-                          LvArray::sortedArrayManipulation::Description::UNSORTED_WITH_DUPLICATES );
+  arrayOfSets.assimilate< RAJA::loop_exec >( std::move( arrayOfArrays ),
+                                             LvArray::sortedArrayManipulation::Description::UNSORTED_WITH_DUPLICATES );
 
   EXPECT_EQ( arrayOfSets.size(), 2 );
   EXPECT_EQ( arrayOfSets.sizeOfSet( 0 ), 2 );

--- a/src/ArrayOfArrays.hpp
+++ b/src/ArrayOfArrays.hpp
@@ -201,6 +201,7 @@ public:
   }
 
   using ParentClass::resizeFromCapacities;
+  using ParentClass::resizeFromOffsets;
 
   ///@}
 

--- a/src/ArrayOfArraysView.hpp
+++ b/src/ArrayOfArraysView.hpp
@@ -33,8 +33,8 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_CHECK_BOUNDS( i ) \
-  LVARRAY_ERROR_IF( !arrayManipulation::isPositive( i ) || i >= this->size(), \
-                    "Bounds Check Failed: i=" << i << " size()=" << this->size() )
+  LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i >= this->size(), \
+                           "Bounds Check Failed: i=%" PRId64 " size()=%" PRId64, (int64_t)i, (int64_t)this->size() )
 
 /**
  * @brief Check that @p i is a valid array index and that @p j is a valid index into that array.
@@ -43,10 +43,11 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_CHECK_BOUNDS2( i, j ) \
-  LVARRAY_ERROR_IF( !arrayManipulation::isPositive( i ) || i >= this->size() || \
-                    !arrayManipulation::isPositive( j ) || j >= this->m_sizes[ i ], \
-                    "Bounds Check Failed: i=" << i << " size()=" << this->size() << \
-                    " j=" << j << " m_sizes[ i ]=" << this->m_sizes[ i ] )
+  LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i >= this->size() || \
+                           !arrayManipulation::isPositive( j ) || j >= this->m_sizes[ i ], \
+                           "Bounds Check Failed: i=%" PRId64 " size()=%" PRId64 \
+                           " j=%" PRId64 " m_sizes[ i ]=%" PRId64,      \
+                           (int64_t)i, (int64_t)this->size(), (int64_t)j, (int64_t)this->m_sizes[ i ] )
 
 /**
  * @brief Check that @p i is a valid index to insert an array at.
@@ -54,8 +55,9 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_CHECK_INSERT_BOUNDS( i ) \
-  LVARRAY_ERROR_IF( !arrayManipulation::isPositive( i ) || i > this->size(), \
-                    "Insert Bounds Check Failed: i=" << i << " size()=" << this->size() )
+  LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i > this->size(), \
+                           "Insert Bounds Check Failed: i=%" PRId64 " size()=%" PRId64, \
+                           (int64_t)i,  (int64_t)this->size() )
 
 /**
  * @brief Check that @p i is a valid array index and that @p j is a valid insertion index into that array.
@@ -64,10 +66,10 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_CHECK_INSERT_BOUNDS2( i, j ) \
-  LVARRAY_ERROR_IF( !arrayManipulation::isPositive( i ) || i >= this->size() || \
-                    !arrayManipulation::isPositive( j ) || j > this->sizeOfArray( i ), \
-                    "Insert Bounds Check Failed: i=" << i << " size()=" << this->size() << \
-                    " j=" << j << " sizeOfArray( i )=" << this->sizeOfArray( i ) )
+  LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i >= this->size() || \
+                           !arrayManipulation::isPositive( j ) || j > this->sizeOfArray( i ), \
+                           "Insert Bounds Check Failed: i=%" PRId64 " size()=%" PRId64 " j=%" PRId64 " sizeOfArray( i )=%" PRId64, \
+                           (int64_t)i , (int64_t)this->size(), (int64_t)j, (int64_t)this->sizeOfArray( i ) )
 
 /**
  * @brief Check that the capacity of array @p i isn't exceeded when the size is increased by @p increase.
@@ -76,10 +78,10 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_CAPACITY_CHECK( i, increase ) \
-  LVARRAY_ERROR_IF( this->sizeOfArray( i ) + increase > this->capacityOfArray( i ), \
-                    "Capacity Check Failed: i=" << i << " increase=" << increase << \
-                    " sizeOfArray( i )=" << this->sizeOfArray( i ) << " capacityOfArray( i )=" << \
-                    this->capacityOfArray( i ) )
+  LVARRAY_ERROR_IF_PRINTF( this->sizeOfArray( i ) + increase > this->capacityOfArray( i ), \
+                           "Capacity Check Failed: i=%" PRId64 " increase=%" PRId64 \
+                           " sizeOfArray( i )=%" PRId64 " capacityOfArray( i )=%" PRId64, \
+                           (int64_t)i, (int64_t)increase, (int64_t)this->sizeOfArray( i ), (int64_t)this->capacityOfArray( i ) )
 
 /**
  * @brief Check that the capacity of array @p i isn't exceeded when the size is increased by @p increase.
@@ -89,10 +91,10 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_ATOMIC_CAPACITY_CHECK( i, previousSize, increase ) \
-  LVARRAY_ERROR_IF( previousSize + increase > this->capacityOfArray( i ), \
-                    "Capacity Check Failed: i=" << i << " increase=" << increase << \
-                    " sizeOfArray( i )=" << previousSize << " capacityOfArray( i )=" << \
-                    this->capacityOfArray( i ) )
+  LVARRAY_ERROR_IF_PRINTF( previousSize + increase > this->capacityOfArray( i ), \
+                           "Capacity Check Failed: i=%" PRId64 " increase=%" PRId64 \
+                           " sizeOfArray( i )=%" PRId64 " capacityOfArray( i )=%" PRId64, \
+                           (int64_t)i, (int64_t)increase, (int64_t)previousSize, (int64_t)this->capacityOfArray( i ) )
 
 #else // LVARRAY_BOUNDS_CHECK
 

--- a/src/ArrayOfArraysView.hpp
+++ b/src/ArrayOfArraysView.hpp
@@ -59,7 +59,7 @@
 #define ARRAYOFARRAYS_CHECK_INSERT_BOUNDS( i ) \
   LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i > this->size(), \
                            "Insert Bounds Check Failed: i=%" PRId64 " size()=%" PRId64, \
-                           (int64_t)i,  (int64_t)this->size() )
+                           (int64_t)i, (int64_t)this->size() )
 
 /**
  * @brief Check that @p i is a valid array index and that @p j is a valid insertion index into that array.
@@ -71,7 +71,7 @@
   LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i >= this->size() || \
                            !arrayManipulation::isPositive( j ) || j > this->sizeOfArray( i ), \
                            "Insert Bounds Check Failed: i=%" PRId64 " size()=%" PRId64 " j=%" PRId64 " sizeOfArray( i )=%" PRId64, \
-                           (int64_t)i , (int64_t)this->size(), (int64_t)j, (int64_t)this->sizeOfArray( i ) )
+                           (int64_t)i, (int64_t)this->size(), (int64_t)j, (int64_t)this->sizeOfArray( i ) )
 
 /**
  * @brief Check that the capacity of array @p i isn't exceeded when the size is increased by @p increase.

--- a/src/ArrayOfArraysView.hpp
+++ b/src/ArrayOfArraysView.hpp
@@ -57,7 +57,7 @@
 #define ARRAYOFARRAYS_CHECK_INSERT_BOUNDS( i ) \
   LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i > this->size(), \
                            "Insert Bounds Check Failed: i=%" PRId64 " size()=%" PRId64, \
-                           (int64_t)i,  (int64_t)this->size() )
+                           (int64_t)i, (int64_t)this->size() )
 
 /**
  * @brief Check that @p i is a valid array index and that @p j is a valid insertion index into that array.
@@ -69,7 +69,7 @@
   LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i >= this->size() || \
                            !arrayManipulation::isPositive( j ) || j > this->sizeOfArray( i ), \
                            "Insert Bounds Check Failed: i=%" PRId64 " size()=%" PRId64 " j=%" PRId64 " sizeOfArray( i )=%" PRId64, \
-                           (int64_t)i , (int64_t)this->size(), (int64_t)j, (int64_t)this->sizeOfArray( i ) )
+                           (int64_t)i, (int64_t)this->size(), (int64_t)j, (int64_t)this->sizeOfArray( i ) )
 
 /**
  * @brief Check that the capacity of array @p i isn't exceeded when the size is increased by @p increase.

--- a/src/ArrayOfArraysView.hpp
+++ b/src/ArrayOfArraysView.hpp
@@ -35,8 +35,8 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_CHECK_BOUNDS( i ) \
-  LVARRAY_ERROR_IF( !arrayManipulation::isPositive( i ) || i >= this->size(), \
-                    "Bounds Check Failed: i=" << i << " size()=" << this->size() )
+  LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i >= this->size(), \
+                           "Bounds Check Failed: i=%" PRId64 " size()=%" PRId64, (int64_t)i, (int64_t)this->size() )
 
 /**
  * @brief Check that @p i is a valid array index and that @p j is a valid index into that array.
@@ -45,10 +45,11 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_CHECK_BOUNDS2( i, j ) \
-  LVARRAY_ERROR_IF( !arrayManipulation::isPositive( i ) || i >= this->size() || \
-                    !arrayManipulation::isPositive( j ) || j >= this->m_sizes[ i ], \
-                    "Bounds Check Failed: i=" << i << " size()=" << this->size() << \
-                    " j=" << j << " m_sizes[ i ]=" << this->m_sizes[ i ] )
+  LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i >= this->size() || \
+                           !arrayManipulation::isPositive( j ) || j >= this->m_sizes[ i ], \
+                           "Bounds Check Failed: i=%" PRId64 " size()=%" PRId64 \
+                           " j=%" PRId64 " m_sizes[ i ]=%" PRId64,      \
+                           (int64_t)i, (int64_t)this->size(), (int64_t)j, (int64_t)this->m_sizes[ i ] )
 
 /**
  * @brief Check that @p i is a valid index to insert an array at.
@@ -56,8 +57,9 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_CHECK_INSERT_BOUNDS( i ) \
-  LVARRAY_ERROR_IF( !arrayManipulation::isPositive( i ) || i > this->size(), \
-                    "Insert Bounds Check Failed: i=" << i << " size()=" << this->size() )
+  LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i > this->size(), \
+                           "Insert Bounds Check Failed: i=%" PRId64 " size()=%" PRId64, \
+                           (int64_t)i,  (int64_t)this->size() )
 
 /**
  * @brief Check that @p i is a valid array index and that @p j is a valid insertion index into that array.
@@ -66,10 +68,10 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_CHECK_INSERT_BOUNDS2( i, j ) \
-  LVARRAY_ERROR_IF( !arrayManipulation::isPositive( i ) || i >= this->size() || \
-                    !arrayManipulation::isPositive( j ) || j > this->sizeOfArray( i ), \
-                    "Insert Bounds Check Failed: i=" << i << " size()=" << this->size() << \
-                    " j=" << j << " sizeOfArray( i )=" << this->sizeOfArray( i ) )
+  LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( i ) || i >= this->size() || \
+                           !arrayManipulation::isPositive( j ) || j > this->sizeOfArray( i ), \
+                           "Insert Bounds Check Failed: i=%" PRId64 " size()=%" PRId64 " j=%" PRId64 " sizeOfArray( i )=%" PRId64, \
+                           (int64_t)i , (int64_t)this->size(), (int64_t)j, (int64_t)this->sizeOfArray( i ) )
 
 /**
  * @brief Check that the capacity of array @p i isn't exceeded when the size is increased by @p increase.
@@ -78,10 +80,10 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_CAPACITY_CHECK( i, increase ) \
-  LVARRAY_ERROR_IF( this->sizeOfArray( i ) + increase > this->capacityOfArray( i ), \
-                    "Capacity Check Failed: i=" << i << " increase=" << increase << \
-                    " sizeOfArray( i )=" << this->sizeOfArray( i ) << " capacityOfArray( i )=" << \
-                    this->capacityOfArray( i ) )
+  LVARRAY_ERROR_IF_PRINTF( this->sizeOfArray( i ) + increase > this->capacityOfArray( i ), \
+                           "Capacity Check Failed: i=%" PRId64 " increase=%" PRId64 \
+                           " sizeOfArray( i )=%" PRId64 " capacityOfArray( i )=%" PRId64, \
+                           (int64_t)i, (int64_t)increase, (int64_t)this->sizeOfArray( i ), (int64_t)this->capacityOfArray( i ) )
 
 /**
  * @brief Check that the capacity of array @p i isn't exceeded when the size is increased by @p increase.
@@ -91,10 +93,10 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYOFARRAYS_ATOMIC_CAPACITY_CHECK( i, previousSize, increase ) \
-  LVARRAY_ERROR_IF( previousSize + increase > this->capacityOfArray( i ), \
-                    "Capacity Check Failed: i=" << i << " increase=" << increase << \
-                    " sizeOfArray( i )=" << previousSize << " capacityOfArray( i )=" << \
-                    this->capacityOfArray( i ) )
+  LVARRAY_ERROR_IF_PRINTF( previousSize + increase > this->capacityOfArray( i ), \
+                           "Capacity Check Failed: i=%" PRId64 " increase=%" PRId64 \
+                           " sizeOfArray( i )=%" PRId64 " capacityOfArray( i )=%" PRId64, \
+                           (int64_t)i, (int64_t)increase, (int64_t)previousSize, (int64_t)this->capacityOfArray( i ) )
 
 #else // LVARRAY_BOUNDS_CHECK
 

--- a/src/ArraySlice.hpp
+++ b/src/ArraySlice.hpp
@@ -240,7 +240,7 @@ public:
    */
   template< typename ... INDICES >
   LVARRAY_HOST_DEVICE inline CONSTEXPR_WITHOUT_BOUNDS_CHECK
-  INDEX_TYPE linearIndex( INDICES... indices ) const
+  std::size_t linearIndex( INDICES... indices ) const
   {
     static_assert( sizeof ... (INDICES) == NDIM, "number of indices does not match NDIM" );
 #ifdef LVARRAY_BOUNDS_CHECK

--- a/src/ArraySlice.hpp
+++ b/src/ArraySlice.hpp
@@ -53,8 +53,9 @@ DEFINE_GDB_PY_SCRIPT( "scripts/gdb-printers.py" )
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAY_SLICE_CHECK_BOUNDS( index ) \
-  LVARRAY_ERROR_IF( index < 0 || index >= m_dims[ 0 ], \
-                    "Array Bounds Check Failed: index=" << index << " m_dims[0]=" << m_dims[0] )
+  LVARRAY_ERROR_IF_PRINTF( index < 0 || index >= m_dims[ 0 ], \
+                           "Array Bounds Check Failed: index=%" PRId64 " m_dims[0]=%" PRId64, \
+                           ((int64_t)index), ((int64_t)m_dims[0]) )
 
 #else // LVARRAY_BOUNDS_CHECK
 

--- a/src/ArrayView.hpp
+++ b/src/ArrayView.hpp
@@ -450,7 +450,7 @@ public:
    */
   template< typename ... INDICES >
   LVARRAY_HOST_DEVICE inline CONSTEXPR_WITHOUT_BOUNDS_CHECK
-  INDEX_TYPE linearIndex( INDICES const ... indices ) const
+  std::size_t linearIndex( INDICES const ... indices ) const
   {
     static_assert( sizeof ... (INDICES) == NDIM, "number of indices does not match NDIM" );
 #ifdef LVARRAY_BOUNDS_CHECK

--- a/src/CRSMatrix.hpp
+++ b/src/CRSMatrix.hpp
@@ -177,8 +177,8 @@ public:
   void resizeFromRowCapacities( INDEX_TYPE const nRows, INDEX_TYPE const nCols, INDEX_TYPE const * const rowCapacities )
   {
     LVARRAY_ERROR_IF( !arrayManipulation::isPositive( nCols ), "nCols must be positive." );
-    LVARRAY_ERROR_IF( nCols - 1 > std::numeric_limits< COL_TYPE >::max(),
-                      "COL_TYPE must be able to hold the range of columns: [0, " << nCols - 1 << "]." );
+    LVARRAY_ERROR_IF_PRINTF( nCols - 1 > std::numeric_limits< COL_TYPE >::max(),
+                             "COL_TYPE must be able to hold the range of columns: [0, %" PRId64  "].", (int64_t)(nCols -1) );
 
     this->m_numCols = nCols;
     ParentClass::template resizeFromCapacities< POLICY >( nRows, rowCapacities, this->m_entries );

--- a/src/Macros.hpp
+++ b/src/Macros.hpp
@@ -132,8 +132,8 @@
               "***** LOCATION: " LOCATION "\n"                          \
               CUDA_INFORMATION_FMT                                      \
               "***** Controlling expression (should be false): "        \
-              STRINGIZE( EXP ) "\n"                                     \
-                               "***** MSG: " MSG_FMT "\n\n",            \
+              "" STRINGIZE( EXP ) "\n"                                  \
+              "***** MSG: " MSG_FMT "\n\n",                             \
               CUDA_INFORMATION_PARAMS, __VA_ARGS__ );                   \
       CALL_ERROR_HANDLER();                                             \
     }                                                                   \
@@ -159,8 +159,8 @@
               "***** LOCATION: " LOCATION "\n"                          \
               CUDA_INFORMATION_FMT                                      \
               "***** Controlling expression (should be false): "        \
-              STRINGIZE( EXP ) "\n"                                     \
-                               "***** MSG: " STRINGIZE( MSG ) "\n\n",   \
+              "" STRINGIZE( EXP ) "\n"                                  \
+              "***** MSG: " STRINGIZE( MSG ) "\n\n",                    \
               CUDA_INFORMATION_PARAMS );                                \
       CALL_ERROR_HANDLER();                                             \
     }                                                                   \
@@ -177,6 +177,7 @@
       __oss << "***** Controlling expression (should be false): ";      \
       __oss << STRINGIZE( EXP ) << "\n";                                \
       __oss << "***** MSG: " << MSG << "\n";                            \
+      __oss << LvArray::system::stackTrace( true );                     \
       std::cout << __oss.str() << std::endl;                            \
       CALL_ERROR_HANDLER();                                             \
     }                                                                   \

--- a/src/Macros.hpp
+++ b/src/Macros.hpp
@@ -85,8 +85,17 @@
 #define LVARRAY_LOG_VAR( ... ) LVARRAY_LOG( STRINGIZE( __VA_ARGS__ ) << " = " << __VA_ARGS__ )
 
 #if defined(__CUDA_ARCH__)
+/**
+ * @brief Format given to printf to print clockIdx and ThreadIdx informations.
+ */
 #  define CUDA_INFORMATION_FMT "***** Block: [%u, %u, %u]\n***** Thread: [%u, %u, %u]\n%s"
+/**
+ * @brief Parameters corresponding to the CUDA_INFORMATION_FMT
+ */
 #  define CUDA_INFORMATION_PARAMS blockIdx.x, blockIdx.y, blockIdx.z, threadIdx.x, threadIdx.y, threadIdx.z, ""
+/**
+ * @brief Code called to stop the execution when an error is raised.
+ */
 #  define CALL_ERROR_HANDLER() do { asm ( "trap;" ); } while( false )
 #else
 #  define CUDA_INFORMATION_FMT "%s"

--- a/src/Macros.hpp
+++ b/src/Macros.hpp
@@ -87,11 +87,11 @@
 #if defined(__CUDA_ARCH__)
 #  define CUDA_INFORMATION_FMT "***** Block: [%u, %u, %u]\n***** Thread: [%u, %u, %u]\n%s"
 #  define CUDA_INFORMATION_PARAMS blockIdx.x, blockIdx.y, blockIdx.z, threadIdx.x, threadIdx.y, threadIdx.z, ""
-#  define CALL_ERROR_HANDLER() do { asm ( "trap;" ); } while ( false )
+#  define CALL_ERROR_HANDLER() do { asm ( "trap;" ); } while( false )
 #else
 #  define CUDA_INFORMATION_FMT "%s"
 #  define CUDA_INFORMATION_PARAMS ""
-#  define CALL_ERROR_HANDLER() do { LvArray::system::callErrorHandler(); } while ( false )
+#  define CALL_ERROR_HANDLER() do { LvArray::system::callErrorHandler(); } while( false )
 #endif
 
 /**
@@ -107,7 +107,7 @@
  */
 #define LVARRAY_ERROR_IF_PRINTF( EXP, MSG_FMT, ... )                    \
   do                                                                    \
-    {                                                                   \
+  {                                                                     \
     if( EXP )                                                           \
     {                                                                   \
       printf( "***** ERROR\n"                                           \
@@ -115,7 +115,7 @@
               CUDA_INFORMATION_FMT                                      \
               "***** Controlling expression (should be false): "        \
               STRINGIZE( EXP ) "\n"                                     \
-              "***** MSG: " MSG_FMT "\n\n",                             \
+                               "***** MSG: " MSG_FMT "\n\n",            \
               CUDA_INFORMATION_PARAMS, __VA_ARGS__ );                   \
       CALL_ERROR_HANDLER();                                             \
     }                                                                   \
@@ -137,13 +137,13 @@
   {                                                                     \
     if( EXP )                                                           \
     {                                                                   \
-      printf("***** ERROR\n"                                            \
-             "***** LOCATION: " LOCATION "\n"                           \
-             CUDA_INFORMATION_FMT                                       \
-             "***** Controlling expression (should be false): "         \
-             STRINGIZE( EXP ) "\n"                                      \
-             "***** MSG: " STRINGIZE(MSG) "\n\n",                       \
-             CUDA_INFORMATION_PARAMS);                                  \
+      printf( "***** ERROR\n"                                           \
+              "***** LOCATION: " LOCATION "\n"                          \
+              CUDA_INFORMATION_FMT                                      \
+              "***** Controlling expression (should be false): "        \
+              STRINGIZE( EXP ) "\n"                                     \
+                               "***** MSG: " STRINGIZE( MSG ) "\n\n",   \
+              CUDA_INFORMATION_PARAMS );                                \
       CALL_ERROR_HANDLER();                                             \
     }                                                                   \
   } while( false )

--- a/src/Macros.hpp
+++ b/src/Macros.hpp
@@ -98,8 +98,17 @@
  */
 #  define CALL_ERROR_HANDLER() do { asm ( "trap;" ); } while( false )
 #else
+/**
+ * @brief Format given to printf to print clockIdx and ThreadIdx informations.
+ */
 #  define CUDA_INFORMATION_FMT "%s"
+/**
+ * @brief Parameters corresponding to the CUDA_INFORMATION_FMT
+ */
 #  define CUDA_INFORMATION_PARAMS ""
+/**
+ * @brief Code called to stop the execution when an error is raised.
+ */
 #  define CALL_ERROR_HANDLER() do { LvArray::system::callErrorHandler(); } while( false )
 #endif
 

--- a/src/Macros.hpp
+++ b/src/Macros.hpp
@@ -132,8 +132,8 @@
               "***** LOCATION: " LOCATION "\n"                          \
               CUDA_INFORMATION_FMT                                      \
               "***** Controlling expression (should be false): "        \
-              "" STRINGIZE( EXP ) "\n"                                  \
-              "***** MSG: " MSG_FMT "\n\n",                             \
+              STRINGIZE( EXP ) "\n"                                     \
+                               "***** MSG: " MSG_FMT "\n\n",            \
               CUDA_INFORMATION_PARAMS, __VA_ARGS__ );                   \
       CALL_ERROR_HANDLER();                                             \
     }                                                                   \
@@ -159,8 +159,8 @@
               "***** LOCATION: " LOCATION "\n"                          \
               CUDA_INFORMATION_FMT                                      \
               "***** Controlling expression (should be false): "        \
-              "" STRINGIZE( EXP ) "\n"                                  \
-              "***** MSG: " STRINGIZE( MSG ) "\n\n",                    \
+              STRINGIZE( EXP ) "\n"                                     \
+                               "***** MSG: " STRINGIZE( MSG ) "\n\n",   \
               CUDA_INFORMATION_PARAMS );                                \
       CALL_ERROR_HANDLER();                                             \
     }                                                                   \

--- a/src/SortedArrayView.hpp
+++ b/src/SortedArrayView.hpp
@@ -25,8 +25,9 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define SORTEDARRAY_CHECK_BOUNDS( index ) \
-  LVARRAY_ERROR_IF( index < 0 || index >= size(), \
-                    "Array Bounds Check Failed: index=" << index << " size()=" << size())
+  LVARRAY_ERROR_IF_PRINTF( index < 0 || index >= size(), \
+                           "Array Bounds Check Failed: index=%" PRId64 " size()=%" PRId64, \
+                           (int64_t)(index), (int64_t)size())
 
 #else // LVARRAY_BOUNDS_CHECK
 

--- a/src/SparsityPattern.hpp
+++ b/src/SparsityPattern.hpp
@@ -130,8 +130,8 @@ public:
   void resizeFromRowCapacities( INDEX_TYPE const nRows, INDEX_TYPE const nCols, INDEX_TYPE const * const rowCapacities )
   {
     LVARRAY_ERROR_IF( !arrayManipulation::isPositive( nCols ), "nCols must be positive." );
-    LVARRAY_ERROR_IF_PRINTF( nCols - 1 > std::numeric_limits< COL_TYPE >::max(),
-                             "COL_TYPE must be able to hold the range of columns: [0, %" PRId64 "].", (int64_t)(nCols - 1) );
+    LVARRAY_ERROR_IF( nCols - 1 > std::numeric_limits< COL_TYPE >::max(),
+                      "COL_TYPE must be able to hold the range of columns: [0, " << nCols - 1 << "]." );
 
     this->m_numCols = nCols;
     ParentClass::template resizeFromCapacities< POLICY >( nRows, rowCapacities );

--- a/src/SparsityPattern.hpp
+++ b/src/SparsityPattern.hpp
@@ -130,8 +130,8 @@ public:
   void resizeFromRowCapacities( INDEX_TYPE const nRows, INDEX_TYPE const nCols, INDEX_TYPE const * const rowCapacities )
   {
     LVARRAY_ERROR_IF( !arrayManipulation::isPositive( nCols ), "nCols must be positive." );
-    LVARRAY_ERROR_IF( nCols - 1 > std::numeric_limits< COL_TYPE >::max(),
-                      "COL_TYPE must be able to hold the range of columns: [0, " << nCols - 1 << "]." );
+    LVARRAY_ERROR_IF_PRINTF( nCols - 1 > std::numeric_limits< COL_TYPE >::max(),
+                             "COL_TYPE must be able to hold the range of columns: [0, %" PRId64 "].", (int64_t)(nCols - 1) );
 
     this->m_numCols = nCols;
     ParentClass::template resizeFromCapacities< POLICY >( nRows, rowCapacities );

--- a/src/SparsityPatternView.hpp
+++ b/src/SparsityPatternView.hpp
@@ -439,8 +439,8 @@ protected:
   {
     LVARRAY_ERROR_IF( !arrayManipulation::isPositive( nrows ), "nrows must be positive." );
     LVARRAY_ERROR_IF( !arrayManipulation::isPositive( ncols ), "ncols must be positive." );
-    LVARRAY_ERROR_IF_PRINTF( ncols - 1 > std::numeric_limits< COL_TYPE >::max(),
-                      "COL_TYPE must be able to hold the range of columns: [0, %" PRId64 "].", (int64_t)(ncols - 1) );
+    LVARRAY_ERROR_IF( ncols - 1 > std::numeric_limits< COL_TYPE >::max(),
+                      "COL_TYPE must be able to hold the range of columns: [0, " << ncols - 1 << "]." );
 
     m_numCols = ncols;
     ParentClass::resizeImpl( nrows, initialRowCapacity, buffers ... );

--- a/src/SparsityPatternView.hpp
+++ b/src/SparsityPatternView.hpp
@@ -26,8 +26,9 @@
  * @note This macro is only active with LVARRAY_BOUNDS_CHECK.
  */
 #define SPARSITYPATTERN_COLUMN_CHECK( col ) \
-  LVARRAY_ERROR_IF( !arrayManipulation::isPositive( col ) || col >= this->numColumns(), \
-                    "Column Check Failed: col=" << col << " numColumns=" << this->numColumns() )
+  LVARRAY_ERROR_IF_PRINTF( !arrayManipulation::isPositive( col ) || col >= this->numColumns(), \
+                           "Column Check Failed: col=%" PRId64 " numColumns=%" PRId64, \
+                           (int64_t)(col), (int64_t)this->numColumns() )
 
 #else // LVARRAY_BOUNDS_CHECK
 
@@ -438,8 +439,8 @@ protected:
   {
     LVARRAY_ERROR_IF( !arrayManipulation::isPositive( nrows ), "nrows must be positive." );
     LVARRAY_ERROR_IF( !arrayManipulation::isPositive( ncols ), "ncols must be positive." );
-    LVARRAY_ERROR_IF( ncols - 1 > std::numeric_limits< COL_TYPE >::max(),
-                      "COL_TYPE must be able to hold the range of columns: [0, " << ncols - 1 << "]." );
+    LVARRAY_ERROR_IF_PRINTF( ncols - 1 > std::numeric_limits< COL_TYPE >::max(),
+                      "COL_TYPE must be able to hold the range of columns: [0, %" PRId64 "].", (int64_t)(ncols - 1) );
 
     m_numCols = ncols;
     ParentClass::resizeImpl( nrows, initialRowCapacity, buffers ... );

--- a/src/arrayManipulation.hpp
+++ b/src/arrayManipulation.hpp
@@ -28,8 +28,9 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYMANIPULATION_CHECK_BOUNDS( index ) \
-  LVARRAY_ERROR_IF( !isPositive( index ) || index >= size, \
-                    "Array Bounds Check Failed: index=" << index << " size()=" << size )
+  LVARRAY_ERROR_IF_PRINTF( !isPositive( index ) || index >= size, \
+                           "Array Bounds Check Failed: index=%" PRId64 " size()=%" PRId64, \
+                           (int64_t)(index), (int64_t)size )
 
 /**
  * @brief Check that @p index is a valid insertion position in the array.
@@ -37,8 +38,9 @@
  * @note This is only active when LVARRAY_BOUNDS_CHECK is defined.
  */
 #define ARRAYMANIPULATION_CHECK_INSERT_BOUNDS( index ) \
-  LVARRAY_ERROR_IF( !isPositive( index ) || index > size, \
-                    "Array Bounds Insert Check Failed: index=" << index << " size()=" << size )
+  LVARRAY_ERROR_IF_PRINTF( !isPositive( index ) || index > size, \
+                           "Array Bounds Insert Check Failed: index=%" PRId64 " size()=%" PRId64, \
+                           (int64_t)(index), (int64_t)size )
 
 #else // LVARRAY_BOUNDS_CHECK
 

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -45,7 +45,7 @@ struct ConditionalMultiply
    */
   template< typename A, typename B >
   static inline LVARRAY_HOST_DEVICE constexpr auto multiply( A const a, B const b )
-  { return integerConversion<std::size_t>( a ) * integerConversion<std:size_t>( b ); }
+  { return integerConversion< std::size_t >( a ) * integerConversion< std:size_t >( b ); }
 };
 
 /**
@@ -64,7 +64,7 @@ struct ConditionalMultiply< true >
    */
   template< typename A, typename B >
   static inline LVARRAY_HOST_DEVICE constexpr std::size_t multiply( A const a, B const & )
-  { return integerConversion<std::size_t>( a ); }
+  { return integerConversion< std::size_t >( a ); }
 };
 
 /**

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -45,7 +45,7 @@ struct ConditionalMultiply
    */
   template< typename A, typename B >
   static inline LVARRAY_HOST_DEVICE constexpr auto multiply( A const a, B const b )
-  { return integerConversion< std::size_t >( a ) * integerConversion< std:size_t >( b ); }
+  { return integerConversion< std::size_t >( a ) * integerConversion< std::size_t >( b ); }
 };
 
 /**
@@ -123,7 +123,7 @@ LVARRAY_HOST_DEVICE inline constexpr
 std::size_t getLinearIndex( INDEX_TYPE const * const LVARRAY_RESTRICT strides, INDEX const index, REMAINING_INDICES const ... indices )
 {
   return ConditionalMultiply< USD == 0 >::multiply( index, strides[ 0 ] ) +
-         getLinearIndex< USD - 1, INDEX_TYPE, REMAINING_INDICES... >( strides + 1, indices ... );
+         getLinearIndex< USD - 1, INDEX_TYPE, REMAINING_INDICES ... >( strides + 1, indices ... );
 }
 
 /// @return A string representing an empty set of indices.

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -45,7 +45,7 @@ struct ConditionalMultiply
    */
   template< typename A, typename B >
   static inline LVARRAY_HOST_DEVICE constexpr auto multiply( A const a, B const b )
-  { return a * b; }
+  { return integerConversion<std::size_t>( a ) * integerConversion<std:size_t>( b ); }
 };
 
 /**
@@ -63,8 +63,8 @@ struct ConditionalMultiply< true >
    * @code  ConditionalMultiply< true >( 5, *static_cast< int * >( nullptr ) ) @endcode.
    */
   template< typename A, typename B >
-  static inline LVARRAY_HOST_DEVICE constexpr A multiply( A const a, B const & )
-  { return a; }
+  static inline LVARRAY_HOST_DEVICE constexpr std::size_t multiply( A const a, B const & )
+  { return integerConversion<std::size_t>( a ); }
 };
 
 /**
@@ -103,7 +103,7 @@ multiplyAll( T const * const LVARRAY_RESTRICT values )
  */
 template< int USD, typename INDEX_TYPE, typename INDEX >
 LVARRAY_HOST_DEVICE inline constexpr
-INDEX_TYPE getLinearIndex( INDEX_TYPE const * const LVARRAY_RESTRICT strides, INDEX const index )
+std::size_t getLinearIndex( INDEX_TYPE const * const LVARRAY_RESTRICT strides, INDEX const index )
 { return ConditionalMultiply< USD == 0 >::multiply( index, strides[ 0 ] ); }
 
 /**
@@ -120,7 +120,7 @@ INDEX_TYPE getLinearIndex( INDEX_TYPE const * const LVARRAY_RESTRICT strides, IN
  */
 template< int USD, typename INDEX_TYPE, typename INDEX, typename ... REMAINING_INDICES >
 LVARRAY_HOST_DEVICE inline constexpr
-INDEX_TYPE getLinearIndex( INDEX_TYPE const * const LVARRAY_RESTRICT strides, INDEX const index, REMAINING_INDICES const ... indices )
+std::size_t getLinearIndex( INDEX_TYPE const * const LVARRAY_RESTRICT strides, INDEX const index, REMAINING_INDICES const ... indices )
 {
   return ConditionalMultiply< USD == 0 >::multiply( index, strides[ 0 ] ) +
          getLinearIndex< USD - 1, INDEX_TYPE, REMAINING_INDICES... >( strides + 1, indices ... );

--- a/src/limits.hpp
+++ b/src/limits.hpp
@@ -136,7 +136,7 @@ std::enable_if_t< internal::canEasilyConvert< INPUT, OUTPUT >, OUTPUT >
 inline constexpr LVARRAY_HOST_DEVICE
 integerConversion( INPUT input )
 {
-  static_assert( std::is_integral< INPUT >::value, "INPUT must be an integral type." );
+  static_assert( std::is_integral< INPUT >::value || std::is_enum< INPUT >::value, "INPUT must be an integral type." );
   static_assert( std::is_integral< OUTPUT >::value, "OUTPUT must be an integral type." );
 
 //  return OUTPUT{ input };

--- a/src/limits.hpp
+++ b/src/limits.hpp
@@ -156,7 +156,7 @@ std::enable_if_t< !internal::canEasilyConvert< INPUT, OUTPUT > &&
 inline LVARRAY_HOST_DEVICE
 integerConversion( INPUT input )
 {
-  static_assert( std::is_integral< INPUT >::value, "INPUT must be an integral type." );
+  static_assert( std::is_integral< INPUT >::value || std::is_enum< INPUT >::value, "INPUT must be an integral type." );
   static_assert( std::is_integral< OUTPUT >::value, "OUTPUT must be an integral type." );
 
   LVARRAY_ERROR_IF_GT( input, NumericLimits< OUTPUT >::max );
@@ -177,7 +177,7 @@ std::enable_if_t< !internal::canEasilyConvert< INPUT, OUTPUT > &&
 inline LVARRAY_HOST_DEVICE
 integerConversion( INPUT input )
 {
-  static_assert( std::is_integral< INPUT >::value, "INPUT must be an integral type." );
+  static_assert( std::is_integral< INPUT >::value || std::is_enum< INPUT >::value, "INPUT must be an integral type." );
   static_assert( std::is_integral< OUTPUT >::value, "OUTPUT must be an integral type." );
 
   LVARRAY_ERROR_IF_LT( input, std::make_signed_t< OUTPUT >{ NumericLimits< OUTPUT >::min } );

--- a/unitTests/testArrayOfArrays.cpp
+++ b/unitTests/testArrayOfArrays.cpp
@@ -233,6 +233,41 @@ public:
     COMPARE_TO_REFERENCE;
   }
 
+  void resizeFromOffsets( IndexType const newSize, IndexType const maxCapacity )
+  {
+    COMPARE_TO_REFERENCE;
+
+    std::vector< IndexType > newCapacities( newSize );
+
+    for( IndexType & capacity : newCapacities )
+    {
+      capacity = rand( 0, maxCapacity );
+    }
+
+    std::vector< IndexType > newOffsets( newSize + 1 );
+
+    IndexType totalOffset = 0;
+    for( IndexType i = 0; i < newSize; ++i )
+    {
+      newOffsets[i] = totalOffset;
+      totalOffset += newCapacities[i];
+    }
+    newOffsets.back() = totalOffset;
+
+    m_array.resizeFromOffsets( newSize, newOffsets.data() );
+
+    EXPECT_EQ( m_array.size(), newSize );
+    for( IndexType i = 0; i < m_array.size(); ++i )
+    {
+      EXPECT_EQ( m_array.sizeOfArray( i ), 0 );
+      EXPECT_EQ( m_array.capacityOfArray( i ), newCapacities[ i ] );
+    }
+
+    m_ref.clear();
+    m_ref.resize( newSize );
+    COMPARE_TO_REFERENCE;
+  }
+
   void resize()
   {
     COMPARE_TO_REFERENCE;
@@ -746,6 +781,15 @@ TYPED_TEST( ArrayOfArraysTest, resizeFromCapacities )
     this->template resizeFromCapacities< parallelHostPolicy >( 150, 10 );
     this->emplace( 10 );
 #endif
+  }
+}
+
+TYPED_TEST( ArrayOfArraysTest, resizeFromOffsets )
+{
+  for( int i = 0; i < 3; ++i )
+  {
+    this->resizeFromOffsets( 100, 10 );
+    this->emplace( 10 );
   }
 }
 


### PR DESCRIPTION
Attempt to solve issue #254.
Added new macro to use printf on device with clearer message.
Still not perfect, we don't know were we are when the error is raised.

Now the dimensions are correctly printed:
***** ERROR
***** LOCATION: /work206/workrd/users/lacoste_x/remote_builds/GEOSX/src/coreComponents/LvArray/src/ArraySlice.hpp:295
***** Block: [3, 0, 0]
***** Thread: [16, 0, 0]
***** Controlling expression (should be false): index < 0 || index >= m_dims[ 0 ]
***** MSG: Array Bounds Check Failed: index=8 m_dims[0]=8
