### PR TITLE
Enhancements for ArrayOf[Arrays|Sets] construction/assimilation

### DIFF
--- a/examples/exampleArrayOfSets.cpp
+++ b/examples/exampleArrayOfSets.cpp
@@ -59,8 +59,8 @@ TEST( ArrayOfSets, assimilate )
   arrayOfArrays.emplaceBack( 2, 1 );
 
   // Assimilate arrayOfArrays into arrayOfSets.
-  arrayOfSets.assimilate( std::move( arrayOfArrays ),
-                          LvArray::sortedArrayManipulation::Description::SORTED_UNIQUE );
+  arrayOfSets.assimilate< RAJA::loop_exec >( std::move( arrayOfArrays ),
+                                             LvArray::sortedArrayManipulation::Description::SORTED_UNIQUE );
 
   // After being assimilated arrayOfArrays is empty.
   EXPECT_EQ( arrayOfArrays.size(), 0 );
@@ -84,8 +84,8 @@ TEST( ArrayOfSets, assimilate )
   arrayOfArrays.emplaceBack( 1, 4 );
 
   // Assimilate the arrayOfArrays yet again.
-  arrayOfSets.assimilate( std::move( arrayOfArrays ),
-                          LvArray::sortedArrayManipulation::Description::UNSORTED_WITH_DUPLICATES );
+  arrayOfSets.assimilate< RAJA::loop_exec >( std::move( arrayOfArrays ),
+                                             LvArray::sortedArrayManipulation::Description::UNSORTED_WITH_DUPLICATES );
 
   EXPECT_EQ( arrayOfSets.size(), 2 );
   EXPECT_EQ( arrayOfSets.sizeOfSet( 0 ), 2 );

--- a/src/ArrayOfArrays.hpp
+++ b/src/ArrayOfArrays.hpp
@@ -201,6 +201,7 @@ public:
   }
 
   using ParentClass::resizeFromCapacities;
+  using ParentClass::resizeFromOffsets;
 
   ///@}
 

--- a/src/ArrayOfArraysView.hpp
+++ b/src/ArrayOfArraysView.hpp
@@ -19,6 +19,7 @@
 #include "ArraySlice.hpp"
 #include "typeManipulation.hpp"
 #include "math.hpp"
+#include "umpireInterface.hpp"
 
 // TPL includes
 #include <RAJA/RAJA.hpp>
@@ -687,6 +688,27 @@ protected:
   }
 
   /**
+   * @brief Clears the array and creates a new array with the given number of sub-arrays.
+   * @param numSubArrays The new number of arrays.
+   * @param offsets A pointer to an array of length @p numSubArrays+1 containing the offset
+   *   of each new sub array. Offsets are precomputed by the caller.
+   * @param buffers A variadic pack of buffers to treat similarly to m_values.
+   */
+  template< typename ... BUFFERS >
+  void resizeFromOffsets( INDEX_TYPE const numSubArrays,
+                          INDEX_TYPE const * const offsets,
+                          BUFFERS & ... buffers )
+  {
+    auto const fillOffsets = [&]()
+    {
+      arrayManipulation::uninitializedCopy( offsets,
+                                            offsets + numSubArrays + 1,
+                                            m_offsets.data() );
+    };
+    resizeFromOffsetsImpl( numSubArrays, fillOffsets, buffers ... );
+  }
+
+  /**
    * @tparam POLICY The RAJA policy used to convert @p capacities into the offsets array.
    *   Should NOT be a device policy.
    * @brief Clears the array and creates a new array with the given number of sub-arrays.
@@ -700,72 +722,14 @@ protected:
                              INDEX_TYPE const * const capacities,
                              BUFFERS & ... buffers )
   {
-    LVARRAY_ASSERT( arrayManipulation::isPositive( numSubArrays ) );
-
-  #ifdef LVARRAY_BOUNDS_CHECK
-    for( INDEX_TYPE i = 0; i < numSubArrays; ++i )
+    auto const fillOffsets = [&]()
     {
-      LVARRAY_ERROR_IF_LT( capacities[ i ], 0 );
-    }
-  #endif
-
-    destroyValues( 0, m_numArrays, buffers ... );
-
-    bufferManipulation::reserve( m_sizes, m_numArrays, MemorySpace::host, numSubArrays );
-    std::fill_n( m_sizes.data(), numSubArrays, 0 );
-
-    INDEX_TYPE const offsetsSize = ( m_numArrays == 0 ) ? 0 : m_numArrays + 1;
-    bufferManipulation::reserve( m_offsets, offsetsSize, MemorySpace::host, numSubArrays + 1 );
-
-    m_offsets[ 0 ] = 0;
-    // RAJA::inclusive_scan fails on empty input range
-    if( numSubArrays > 0 )
-    {
+      m_offsets[ 0 ] = 0;
       RAJA::inclusive_scan< POLICY >( capacities,
                                       capacities + numSubArrays,
                                       m_offsets.data() + 1 );
-    }
-
-    m_numArrays = numSubArrays;
-    INDEX_TYPE const maxOffset = m_offsets[ m_numArrays ];
-    typeManipulation::forEachArg( [ maxOffset] ( auto & buffer )
-    {
-      bufferManipulation::reserve( buffer, 0, MemorySpace::host, maxOffset );
-    }, m_values, buffers ... );
-  }
-
-  /**
-   * @brief Clears the array and creates a new array with the given number of sub-arrays.
-   * @param numSubArrays The new number of arrays.
-   * @param offsets A pointer to an array of length @p numSubArrays+1 containing the offset
-   *   of each new sub array. Offsets are precomputed by the caller.
-   * @param buffers A variadic pack of buffers to treat similarly to m_values.
-   */
-  template< typename ... BUFFERS >
-  void resizeFromOffsets( INDEX_TYPE const numSubArrays,
-                          INDEX_TYPE const * const offsets,
-                          BUFFERS & ... buffers )
-  {
-    LVARRAY_ASSERT( arrayManipulation::isPositive( numSubArrays ) );
-    LVARRAY_ASSERT_EQ( offsets[0], 0 );
-    LVARRAY_ASSERT( sortedArrayManipulation::isSorted( offsets, offsets + numSubArrays + 1 ) );
-
-    destroyValues( 0, m_numArrays, buffers ... );
-
-    bufferManipulation::reserve( m_sizes, m_numArrays, MemorySpace::host, numSubArrays );
-    std::fill_n( m_sizes.data(), numSubArrays, 0 );
-
-    INDEX_TYPE const offsetsSize = ( m_numArrays == 0 ) ? 0 : m_numArrays + 1;
-    bufferManipulation::reserve( m_offsets, offsetsSize, MemorySpace::host, numSubArrays + 1 );
-
-    arrayManipulation::uninitializedCopy( offsets, offsets + numSubArrays + 1, m_offsets.data() );
-
-    m_numArrays = numSubArrays;
-    INDEX_TYPE const maxOffset = m_offsets[ m_numArrays ];
-    typeManipulation::forEachArg( [ maxOffset ] ( auto & buffer )
-    {
-      bufferManipulation::reserve( buffer, 0, MemorySpace::host, maxOffset );
-    }, m_values, buffers ... );
+    };
+    resizeFromOffsetsImpl( numSubArrays, fillOffsets, buffers ... );
   }
 
   ///@}
@@ -1040,6 +1004,40 @@ private:
           arrayManipulation::destroy( &buffer[ offset ], arraySize );
         }
       }
+    }, m_values, buffers ... );
+  }
+
+  /**
+   * @brief Clears the array and creates a new array with the given number of sub-arrays.
+   * @param numSubArrays The new number of arrays.
+   * @param fillOffsets A function that will be called to populate sub-array offsets.
+   * @param buffers A variadic pack of buffers to treat similarly to m_values.
+   * @note This is to be called by other resizeFrom functions.
+   */
+  template< typename FUNC, typename ... BUFFERS >
+  void resizeFromOffsetsImpl( INDEX_TYPE const numSubArrays,
+                              FUNC && fillOffsets,
+                              BUFFERS & ... buffers )
+  {
+    LVARRAY_ASSERT( arrayManipulation::isPositive( numSubArrays ) );
+
+    destroyValues( 0, m_numArrays, buffers ... );
+
+    bufferManipulation::reserve( m_sizes, m_numArrays, MemorySpace::host, numSubArrays );
+    umpireInterface::memset( m_sizes.data(), 0, m_sizes.capacity() * sizeof( INDEX_TYPE ) );
+
+    INDEX_TYPE const offsetsSize = ( m_numArrays == 0 ) ? 0 : m_numArrays + 1;
+    bufferManipulation::reserve( m_offsets, offsetsSize, MemorySpace::host, numSubArrays + 1 );
+
+    fillOffsets();
+    LVARRAY_ASSERT_EQ( m_offsets[0], 0 );
+    LVARRAY_ASSERT( sortedArrayManipulation::isSorted( m_offsets.data(), m_offsets.data() + numSubArrays + 1 ) );
+
+    m_numArrays = numSubArrays;
+    INDEX_TYPE const maxOffset = m_offsets[ m_numArrays ];
+    typeManipulation::forEachArg( [ maxOffset ] ( auto & buffer )
+    {
+      bufferManipulation::reserve( buffer, 0, MemorySpace::host, maxOffset );
     }, m_values, buffers ... );
   }
 };

--- a/unitTests/testArrayOfArrays.cpp
+++ b/unitTests/testArrayOfArrays.cpp
@@ -233,6 +233,41 @@ public:
     COMPARE_TO_REFERENCE;
   }
 
+  void resizeFromOffsets( IndexType const newSize, IndexType const maxCapacity )
+  {
+    COMPARE_TO_REFERENCE;
+
+    std::vector< IndexType > newCapacities( newSize );
+
+    for( IndexType & capacity : newCapacities )
+    {
+      capacity = rand( 0, maxCapacity );
+    }
+
+    std::vector< IndexType > newOffsets( newSize + 1 );
+
+    IndexType totalOffset = 0;
+    for( IndexType i = 0; i < newSize; ++i )
+    {
+      newOffsets[i] = totalOffset;
+      totalOffset += newCapacities[i];
+    }
+    newOffsets.back() = totalOffset;
+
+    m_array.resizeFromOffsets( newSize, newOffsets.data() );
+
+    EXPECT_EQ( m_array.size(), newSize );
+    for( IndexType i = 0; i < m_array.size(); ++i )
+    {
+      EXPECT_EQ( m_array.sizeOfArray( i ), 0 );
+      EXPECT_EQ( m_array.capacityOfArray( i ), newCapacities[ i ] );
+    }
+
+    m_ref.clear();
+    m_ref.resize( newSize );
+    COMPARE_TO_REFERENCE;
+  }
+
   void resize()
   {
     COMPARE_TO_REFERENCE;
@@ -746,6 +781,15 @@ TYPED_TEST( ArrayOfArraysTest, resizeFromCapacities )
     this->template resizeFromCapacities< parallelHostPolicy >( 150, 10 );
     this->emplace( 10 );
 #endif
+  }
+}
+
+TYPED_TEST( ArrayOfArraysTest, resizeFromOffsets )
+{
+  for( int i = 0; i < 3; ++i )
+  {
+    this->resizeFromOffsets( 100, 10 );
+    this->emplace( 10 );
   }
 }
 


### PR DESCRIPTION
Related to: https://github.com/GEOSX/GEOSX/pull/1847
  * Add execution policy template parameter to `ArrayOfSets::assimilate()` (can be host or device policy).
  * Add new method `ArrayOfArrays::resizeFromOffsets()`. This is useful when a new `ArrayOfArrays` needs to "inherit" capacity allocations from another existing one (can be extracted via `ArrayOfArraysView::getOffsets()`), but otherwise be resized to empty state.