### PR TITLE
Allow to execute without access to source directory

### DIFF
--- a/unitTests/python/CMakeLists.txt
+++ b/unitTests/python/CMakeLists.txt
@@ -20,8 +20,11 @@ foreach(test ${pythonTests})
 
     target_include_directories( ${test_name} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../../src )
 
+
+    configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}Driver.py ${CMAKE_CURRENT_BINARY_DIR}/${test_name}Driver.py COPY_ONLY )
+
     add_test( NAME ${test_name}
-              COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}Driver.py )
+              COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/${test_name}Driver.py )
 
     set_tests_properties( ${test_name}
                           PROPERTIES ENVIRONMENT PYTHONPATH=${CMAKE_BINARY_DIR}/lib )


### PR DESCRIPTION
Required to launch a make test from a compute node that cannot see source directory (typicall case on Pangea3)