### PR TITLE
Add ubuntu 22.04 to travis host-config change

### DIFF
--- a/host-configs/LLNL/quartz-clang@10.0.0.cmake
+++ b/host-configs/LLNL/quartz-clang@10.0.0.cmake
@@ -4,10 +4,12 @@ set(COMPILER_DIR /usr/tce/packages/clang/clang-10.0.0)
 
 # C
 set(CMAKE_C_COMPILER ${COMPILER_DIR}/bin/clang CACHE PATH "")
+set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE STRING "")
 set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
 
 # C++
 set(CMAKE_CXX_COMPILER ${COMPILER_DIR}/bin/clang++ CACHE PATH "")
+set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.1.0" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -mtune=native" CACHE STRING "")
 
 include(${CMAKE_CURRENT_LIST_DIR}/quartz-base.cmake)


### PR DESCRIPTION
This PR:

- Makes clang@10.0.0 compiler on quartz target the gcc@8.1 toolchain instead of gcc@4.9.3 by default to get around a missing std feature error when compiling trilinos.

Related to GEOSX/GEOSX#2090
Related to GEOSX/thirdPartyLibs#200