### PR TITLE
Throw exceptions instead of errors in stringToArray

### DIFF
--- a/src/Macros.hpp
+++ b/src/Macros.hpp
@@ -180,6 +180,12 @@
     } \
   } while( false )
 
+/**
+ * @brief Throw an exception.
+ * @param MSG The message to associate with the error, can be anything streamable to a std::ostream.
+ */
+#define LVARRAY_THROW( MSG, TYPE ) LVARRAY_THROW_IF( true, MSG, TYPE )
+
 /// Assert @p EXP is true with no message.
 #define LVARRAY_ASSERT( EXP ) LVARRAY_ASSERT_MSG( EXP, "" )
 

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -80,7 +80,7 @@ struct StringToArrayHelper
         INDEX_TYPE const * const dims,
         std::istringstream & inputStream )
   {
-    LVARRAY_THROW_IF( inputStream.peek() != '{', "opening { not found for input array: "<<inputStream.str(),
+    LVARRAY_THROW_IF( inputStream.peek() != '{', "Opening '{' not found for input array: "<<inputStream.str(),
                       std::invalid_argument );
     inputStream.ignore();
 
@@ -91,7 +91,7 @@ struct StringToArrayHelper
     }
 
     skipDelimiters( inputStream );
-    LVARRAY_THROW_IF( inputStream.peek() != '}', "closing } not found for input array: "<<inputStream.str(),
+    LVARRAY_THROW_IF( inputStream.peek() != '}', "Closing '}' not found for input array: "<<inputStream.str(),
                       std::invalid_argument );
     inputStream.ignore();
   }
@@ -183,14 +183,14 @@ static void stringToArray( Array< T, NDIM, PERMUTATION, INDEX_TYPE, BUFFER_TYPE 
                     std::invalid_argument );
 
   LVARRAY_THROW_IF( valueString[0]!='{',
-                    "First non-space character of input string for an array must be {. Given string is: \n"<<valueString,
+                    "First non-space character of input string for an array must be '{'. Given string is: \n"<<valueString,
                     std::invalid_argument );
 
   size_t const numOpen = std::count( valueString.begin(), valueString.end(), '{' );
   size_t const numClose = std::count( valueString.begin(), valueString.end(), '}' );
 
   LVARRAY_THROW_IF( numOpen != numClose,
-                    "Number of opening { not equal to number of } in processing of string for filling"
+                    "Number of opening '{' not equal to number of '}' in processing of string for filling"
                     " an Array. Given string is: \n"<<valueString,
                     std::invalid_argument );
 

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -242,6 +242,10 @@ static void stringToArray( Array< T, NDIM, PERMUTATION, INDEX_TYPE, BUFFER_TYPE 
     }
     else if( c=='}' )
     {
+      LVARRAY_THROW_IF( lastChar==',',
+                        "character '}' follows '"<<lastChar<<"'. Closing brace must follow an array value.",
+                        std::invalid_argument );
+
       // } means that we are closing a dimension. That means we know the size of this dimLevel
       dimSet[dimLevel] = true;
       LVARRAY_THROW_IF( dims[dimLevel]!=currentDims[dimLevel],

--- a/unitTests/testInput.cpp
+++ b/unitTests/testInput.cpp
@@ -38,62 +38,62 @@ TEST( input, stringToArrayErrors )
   {
     input = " { 10 1 } ";
     ArrayT< int, RAJA::PERM_I > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
 
   {
     input = " { { 1, 2 }{ 3, 4 } } ";
     ArrayT< int, RAJA::PERM_IJ > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
 
   // This should fail the num('{')==num('}') test
   {
     input = " { { {0,1,2},{3,4,5} }, { {6,7,8},{9,10,11} }, { {12,13,14},{15,16,17} } , { {18,19,20},{21,22,23} } ";
     ArrayT< int, RAJA::PERM_IJK > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
   {
     input = " { { {0,1,2},{3,4,5} }, { {6,7,8},{9,10,11} }, { {12,13,14},{15,16,17}  , { {18,19,20},{21,22,23} } }";
     ArrayT< int, RAJA::PERM_IKJ > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
   {
     input = " { { {0,1,2},{3,4,5} }, { {6,7,8},{9,10,11} }, { {12,13,14,{15,16,17} } , { {18,19,20},{21,22,23} } }";
     ArrayT< int, RAJA::PERM_JIK > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
   {
     input = " { { {0,1,2},{3,4,5} }, { {6,7,8,{9,10,11} }, { {12,13,14},{15,16,17} } , { {18,19,20},{21,22,23} } }";
     ArrayT< int, RAJA::PERM_JKI > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
   {
     input = " { { 0,1,2},{3,4,5} }, { {6,7,8},{9,10,11} }, { {12,13,14},{15,16,17} } , { {18,19,20},{21,22,23} } }";
     ArrayT< int, RAJA::PERM_KIJ > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
   {
     input = "  { {0,1,2},{3,4,5} }, { {6,7,8},{9,10,11} }, { {12,13,14},{15,16,17} } , { {18,19,20},{21,22,23} } ";
     ArrayT< int, RAJA::PERM_KJI > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
 
   {
     input = " { { {,1,2},{3,4,5} }, { {6,7,8},{9,10,11} }, { {12,13,14},{15,16,17} } , { {18,19,20},{21,22,23} } }";
     ArrayT< int, RAJA::PERM_IJK > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
 
   {
     input = " { { {},{3,4,5} }, { {6,7,8},{9,10,11} }, { {12,13,14},{15,16,17} } , { {18,19,20},{21,22,23} } }";
     ArrayT< int, RAJA::PERM_IJK > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
   {
     input = " { { {0,1,2}}{ } }";
     ArrayT< int, RAJA::PERM_IJK > array;
-    EXPECT_DEATH_IF_SUPPORTED( input::stringToArray( array, input ), IGNORE_OUTPUT );
+    ASSERT_THROW( input::stringToArray( array, input ), std::invalid_argument );
   }
 
 


### PR DESCRIPTION
This PR aims to:
- Throw exceptions from `LvArray::input::stringToArray()` instead of errors. This will help to add context to these parsing errors by catching these exceptions, as a lot of parsing function & method propose to.
- Detect when a token is missing before a '}'
- Slightly reformulate some error messages and add one when a comma is placed just before the ending brace.

[GEOS Issue related: #2320](https://github.com/GEOSX/GEOS/issues/2320)
[GEOS PR : #2357](https://github.com/GEOSX/GEOS/pull/2357)