### PR TITLE
Added nicer errors when you do invalid operations on a ChaiBuffer from device

### DIFF
--- a/src/MallocBuffer.hpp
+++ b/src/MallocBuffer.hpp
@@ -16,6 +16,7 @@
 #include "LvArrayConfig.hpp"
 #include "Macros.hpp"
 #include "bufferManipulation.hpp"
+#include "math.hpp"
 
 // System includes
 #include <stddef.h>
@@ -125,6 +126,7 @@ public:
    * @param space The space to perform the reallocation in, not used.
    * @param newCapacity The new capacity of the buffer.
    */
+  LVARRAY_HOST_DEVICE inline
   void reallocate( std::ptrdiff_t const size, MemorySpace const space, std::ptrdiff_t const newCapacity )
   {
     LVARRAY_ERROR_IF_NE( space, MemorySpace::host );
@@ -132,7 +134,7 @@ public:
     // TODO: If std::is_trivially_copyable_v< T > then we could use std::realloc.
     T * const newPtr = reinterpret_cast< T * >( std::malloc( newCapacity * sizeof( T ) ) );
 
-    std::ptrdiff_t const overlapAmount = std::min( newCapacity, size );
+    std::ptrdiff_t const overlapAmount = math::min( newCapacity, size );
     arrayManipulation::uninitializedMove( newPtr, overlapAmount, m_data );
     arrayManipulation::destroy( m_data, size );
 


### PR DESCRIPTION
Say you try and capture an Array by value in a device lambda, I think we've all made this mistake before

```c++
Array< int, 1, RAJA::PERM_I, std::ptrdiff_t, ChaiBuffer > phi( 10 );
  forall< RAJA::cuda_exec< 32 > >( 10, [=] LVARRAY_DEVICE ( std::ptrdiff_t const i )
  {
    phi( i ) = i;
  } );
```

Previous error message was the result of calling a host function on device

```
unknown file: Failure
C++ exception with description "campCudaErrchk(cudaStreamSynchronize(stream)) an illegal memory access was encountered /usr/gapps/GEOSX/thirdPartyLibs/2023-01-23/install-lassen-clang13-cuda11-release/raja/include/camp/resource/cuda.hpp:172" thrown in the test body.
```

Now you get something clearer, although albeit much longer

```
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [0,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [1,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [2,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [3,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [4,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [5,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [6,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [7,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [8,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [9,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [10,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [11,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [12,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [13,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [14,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [15,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [16,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [17,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [18,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [19,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [20,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [21,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [22,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [23,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [24,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [25,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [26,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [27,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [28,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [29,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [30,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
/usr/WS2/corbett5/geosx/GEOSX/src/coreComponents/LvArray/unitTests/../src/ChaiBuffer.hpp:146: LvArray::ChaiBuffer<T>::ChaiBuffer(__nv_bool) [with T = int]: block: [0,0,0], thread: [31,0,0] Assertion `false && "EXP = " "true" "MSG = " "\"Creating a new ChaiBuffer on device is not supported.\""` failed.
unknown file: Failure
C++ exception with description "campCudaErrchk(cudaStreamSynchronize(stream)) device-side assert triggered /usr/gapps/GEOSX/thirdPartyLibs/2023-01-23/install-lassen-clang13-cuda11-release/raja/include/camp/resource/cuda.hpp:172" thrown in the test body.
```

The only downside I see is that I have to mark certain function in `ChaiBuffer` which should really be host only as host-device. But I don't really see this as a problem since clearly the compiler was fine calling these host functions from device.