### PR TITLE
Changes for Memory-Space Aware Packing

### DIFF
--- a/src/ArrayView.hpp
+++ b/src/ArrayView.hpp
@@ -686,7 +686,7 @@ public:
    * @note The default behavior is that the Buffer can only exist on the CPU and an error
    *   occurs if you try to move it to a different space.
    */
-  bool checkTouch( )
+  bool checkTouch( ) const
   { return m_dataBuffer.checkTouch(); }
 
   /**

--- a/src/ArrayView.hpp
+++ b/src/ArrayView.hpp
@@ -681,6 +681,14 @@ public:
   void registerTouch( MemorySpace const space ) const
   { m_dataBuffer.registerTouch( space ); }
 
+    /**
+   * @return Whether the buffer has been touched in the current space.
+   * @note The default behavior is that the Buffer can only exist on the CPU and an error
+   *   occurs if you try to move it to a different space.
+   */
+  bool checkTouch( )
+  { return m_dataBuffer.checkTouch(); }
+
   /**
    * @brief Move the Array to the given execution space, optionally touching it.
    * @param space the space to move the Array to.

--- a/src/ChaiBuffer.hpp
+++ b/src/ChaiBuffer.hpp
@@ -474,6 +474,17 @@ public:
   }
 
   /**
+   * @return Whether the buffer has been touched in the current space.
+   * @note The default behavior is that the Buffer can only exist on the CPU and an error
+   *   occurs if you try to move it to a different space.
+   */
+  inline
+  bool checkTouch( )
+  {
+    return m_pointerRecord->m_touched[ m_pointerRecord->m_last_space ];
+  }
+
+  /**
    * @tparam U The type of the owning class, will be displayed in the callback.
    * @brief Set the name associated with this buffer which is used in the chai callback.
    * @param name the of the buffer.

--- a/src/ChaiBuffer.hpp
+++ b/src/ChaiBuffer.hpp
@@ -479,7 +479,7 @@ public:
    *   occurs if you try to move it to a different space.
    */
   inline
-  bool checkTouch( )
+  bool checkTouch( ) const
   {
     return m_pointerRecord->m_touched[ m_pointerRecord->m_last_space ];
   }

--- a/src/bufferManipulation.hpp
+++ b/src/bufferManipulation.hpp
@@ -122,6 +122,15 @@ struct VoidBuffer
   { LVARRAY_ERROR_IF_NE_MSG( space, MemorySpace::host, "This Buffer type can only be used on the CPU." ); }
 
   /**
+   * @brief Check if the buffer has been touched in the current space.
+   * @note The default behavior is that the Buffer can only exist on the CPU and an error
+   *   occurs if you try to move it to a different space.
+   */
+  bool checkTouch( ) const
+  { return false; }
+
+
+  /**
    * @tparam The type of the owning object.
    * @brief Set the name associated with this buffer.
    * @param name the name of the buffer.


### PR DESCRIPTION
Basically just adding a `checkTouch` function to determine whether the buffer has been touched in the current memory space so we can avoid unneeded host-packing when a buffer is moved back to host for some other read-only purpose.