### PR TITLE
Add shallow pretty printers and tests

### DIFF
--- a/scripts/gdb-printers-shallow.py
+++ b/scripts/gdb-printers-shallow.py
@@ -111,7 +111,7 @@ class __ArrayPrinter(LvArrayPrinter):
     def children(self) ->  Iterable[tuple[str, gdb.Value]]:
         d0, ds = self.dimensions[0], self.dimensions[1:]
 
-        # The main idea of this loop is to build the mutli-dimensional array type to the data (e.g. `int[2][3]`).
+        # The main idea of this loop is to build the multi-dimensional array type to the data (e.g. `int[2][3]`).
         # Then we'll cast the raw pointer into this n-d array and gdb will be able to manage it.
         array_type: gdb.Type = self.data.type.target()
         for d in reversed(ds):  # Note that we ditch the first dimension from our loop in order to have it as first level children.

--- a/scripts/gdb-printers-shallow.py
+++ b/scripts/gdb-printers-shallow.py
@@ -1,0 +1,176 @@
+import abc
+import logging
+import math
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+)
+import re
+
+import gdb
+
+
+class Buffer(metaclass=abc.ABCMeta):
+    """Base class for accessing buffer contents"""
+
+    def __init__(self, val: gdb.Value, data_key: str):
+        self._val: gdb.Value = val
+        self._data_key: str = data_key
+
+    @abc.abstractmethod
+    def __len__(self) -> int:
+        ...
+
+    def __getitem__(self, key) -> Any:
+        return self.data()[key]
+
+    def data(self) -> gdb.Value:
+        return self._val[self._data_key]
+
+
+class StackBuffer(Buffer):
+
+    def __init__(self, val: gdb.Value):
+        super().__init__(val, "m_data")
+
+    def __len__(self) -> int:
+        return int(self._val.type.template_argument(1))
+
+
+class ChaiBuffer(Buffer):
+
+    def __init__(self, val: gdb.Value):
+        super().__init__(val, "m_pointer")
+
+    def __len__(self) -> int:
+        return int(self._val['m_capacity'])
+
+
+class MallocBuffer(Buffer):
+
+    def __init__(self, val: gdb.Value):
+        super().__init__(val, "m_data")
+
+    def __len__(self) -> int:
+        return int(self._val['m_capacity'])
+
+
+def extract_buffer(val: gdb.Value) -> Buffer:
+    # Use self.val.type.fields() to know the fields.
+    # You can also have a look at the fields of the fields.
+    t: str = str(val.type)
+    if re.match('LvArray::ChaiBuffer<.*>', t):
+        return ChaiBuffer(val)
+    elif re.match('LvArray::StackBuffer<.*>', t):
+        return StackBuffer(val)
+    elif re.match('LvArray::MallocBuffer<.*>', t):
+        return MallocBuffer(val)
+    else:
+        raise ValueError(f"Could not build buffer from `{val.type}`.")
+
+
+class LvArrayPrinter:
+    """Base printer for LvArray classes"""
+
+    def __init__(self, val: gdb.Value):
+        self.val: gdb.Value = val
+
+    def real_type(self) -> gdb.Type:
+        return self.val.type.strip_typedefs()
+
+    def display_hint(self) -> str:
+        return 'array'
+
+
+class __ArrayPrinter(LvArrayPrinter):
+    """Utility class for code factorization"""
+
+    def __init__(self,
+                 val: gdb.Value,
+                 data_extractor: Callable[[gdb.Value], gdb.Value],
+                 dimension_extractor: Callable[[gdb.Value], gdb.Value]):
+        """
+        val: The initial `gdb.Value`. Typically a `LvArray::Array`.
+        data_extractor: How to access the raw data from the initial `val`.
+        dimension_extractor: How to access the dimensions (since this is a multi-dimensional array) from the initial `val`.
+        """
+        super().__init__(val)
+
+        self.data = data_extractor(self.val)
+        dimensions: gdb.Value = dimension_extractor(self.val)
+
+        num_dimensions: int = int(self.val.type.template_argument(1))
+        dimensions: Iterable[gdb.Value] = map(dimensions.__getitem__, range(num_dimensions))
+        self.dimensions: tuple[int] = tuple(map(int, dimensions))
+
+    def to_string(self) -> str:
+        dimensions = map(str, self.dimensions)
+        return f'{self.real_type()} of shape [{", ".join(dimensions)}]'
+
+    def children(self) ->  Iterable[tuple[str, gdb.Value]]:
+        d0, ds = self.dimensions[0], self.dimensions[1:]
+
+        # The main idea of this loop is to build the mutli-dimensional array type to the data (e.g. `int[2][3]`).
+        # Then we'll cast the raw pointer into this n-d array and gdb will be able to manage it.
+        array_type: gdb.Type = self.data.type.target()
+        for d in reversed(ds):  # Note that we ditch the first dimension from our loop in order to have it as first level children.
+            array_type = array_type.array(d - 1)
+
+        # We manage the first level children ourselves, so we need to manage the position of the data ourselves too.
+        stride: int = math.prod(ds)
+
+        for i in range(d0):
+            array = (self.data + i * stride).dereference().cast(array_type)
+            yield '[%d]' % i, array
+
+
+class ArrayPrinter(__ArrayPrinter):
+    """Pretty-print for Array(View)"""
+
+    def __init__(self, val: gdb.Value):
+        super().__init__(val, lambda v: extract_buffer(v["m_dataBuffer"]).data(), lambda v: v["m_dims"]["data"])
+
+
+class ArraySlicePrinter(__ArrayPrinter):
+    """Pretty-print for ArraySlice"""
+
+    def __init__(self, val: gdb.Value):
+        super().__init__(val, lambda v: v["m_data"], lambda v: v["m_dims"])
+
+
+class ArrayOfArraysPrinter(LvArrayPrinter):
+    """Pretty-print for ArrayOfArrays(View)"""
+
+    def __len__(self) -> int:
+        return int(self.val['m_numArrays'])
+
+    def to_string(self) -> str:
+        return '%s of size %d' % (self.real_type(), len(self))
+
+    def children(self) -> Iterable[tuple[str, gdb.Value]]:
+        # In this function, we are walking along the "sub" arrays ourselves.
+        # To do this, we manipulate the raw pointer/offsets information ourselves.
+        data = extract_buffer(self.val["m_values"]).data()
+        offsets = extract_buffer(self.val["m_offsets"])
+        sizes = extract_buffer(self.val["m_sizes"])
+        for i in range(len(self)):  # Iterating over all the "sub" arrays.
+            # Converting a raw pointer `T*` to an equivalent type including the size `T[N]` that gdb will manage.
+            array_type = data.type.target().array(sizes[i] - 1)
+            array = (data + offsets[i]).dereference().cast(array_type)
+            yield '[%d]' % i, array
+
+
+def build_array_printer():
+    pp = gdb.printing.RegexpCollectionPrettyPrinter("my-LvArray-arrays")
+    pp.add_printer('LvArray::Array', '^LvArray::Array(View)?<.*>$', ArrayPrinter)
+    pp.add_printer('LvArray::ArraySlice', '^LvArray::ArraySlice<.*>$', ArraySlicePrinter)
+    pp.add_printer('LvArray::ArrayOfArrays', '^LvArray::ArrayOfArrays(View)?<.*>$', ArrayOfArraysPrinter)
+    return pp
+
+
+try:
+    import gdb.printing
+    gdb.printing.register_pretty_printer(gdb.current_objfile(), build_array_printer())
+except ImportError:
+    logging.warning("Could not register LvArray pretty printers.")

--- a/scripts/gdb-printers-shallow.py
+++ b/scripts/gdb-printers-shallow.py
@@ -162,7 +162,7 @@ class ArrayOfArraysPrinter(LvArrayPrinter):
 
 
 def build_array_printer():
-    pp = gdb.printing.RegexpCollectionPrettyPrinter("my-LvArray-arrays")
+    pp = gdb.printing.RegexpCollectionPrettyPrinter("LvArray-arrays-shallow")
     pp.add_printer('LvArray::Array', '^LvArray::Array(View)?<.*>$', ArrayPrinter)
     pp.add_printer('LvArray::ArraySlice', '^LvArray::ArraySlice<.*>$', ArraySlicePrinter)
     pp.add_printer('LvArray::ArrayOfArrays', '^LvArray::ArrayOfArrays(View)?<.*>$', ArrayOfArraysPrinter)

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -59,13 +59,16 @@ set( testSources
      testIndexing.cpp
      testInput.cpp
      testIntegerConversion.cpp
+     testInvalidOperations.cpp
      testMath.cpp
      testMemcpy.cpp
+     testPrettyPrinters.cpp
      testSliceHelpers.cpp
      testSortedArray.cpp
      testSortedArrayManipulation.cpp
      testSparsityPattern.cpp
      testStackArray.cpp
+     testStackTrace.cpp
      testTensorOpsDeterminant.cpp
      testTensorOpsEigen.cpp
      testTensorOpsInverseOneArg.cpp
@@ -74,8 +77,6 @@ set( testSources
      testTensorOpsSymInverseOneArg.cpp
      testTensorOpsSymInverseTwoArgs.cpp
      testTypeManipulation.cpp
-     testStackTrace.cpp
-     testInvalidOperations.cpp
    )
 
 blt_list_append( TO testSources ELEMENTS testChaiBuffer.cpp testArray_ChaiBuffer.cpp IF ENABLE_CHAI )

--- a/unitTests/testPrettyPrinters.cpp
+++ b/unitTests/testPrettyPrinters.cpp
@@ -1,9 +1,8 @@
 #include "Array.hpp"
 #include "ArrayOfArrays.hpp"
-#include <RAJA/util/Permutations.hpp>
-
 #include "MallocBuffer.hpp"
 
+#include <RAJA/util/Permutations.hpp>
 
 void breakpoint_helper()
 {

--- a/unitTests/testPrettyPrinters.cpp
+++ b/unitTests/testPrettyPrinters.cpp
@@ -30,7 +30,7 @@ int main()
   v1.emplace_back( 2 );
 
   auto v1v = v1.toView();
-  LVARRAY_LOG( v1v[0] );
+  LVARRAY_LOG( v1v[0] );  // Calling `LVARRAY_LOG` to prevent the variable from being unused.
   auto v1vc = v1.toViewConst();
   LVARRAY_LOG( v1vc[0] );
 

--- a/unitTests/testPrettyPrinters.cpp
+++ b/unitTests/testPrettyPrinters.cpp
@@ -1,0 +1,94 @@
+#include "Array.hpp"
+#include "ArrayOfArrays.hpp"
+#include <RAJA/util/Permutations.hpp>
+
+#include "MallocBuffer.hpp"
+
+
+void breakpoint_helper()
+{
+  // Left blank. This function is there to be used as a breakpoint for gdb.
+}
+
+
+template< typename T >
+using array1d = LvArray::Array< int, 1, RAJA::PERM_I, int, LvArray::MallocBuffer >;
+template< typename T >
+using array2d = LvArray::Array< int, 2, RAJA::PERM_IJ, int, LvArray::MallocBuffer >;
+template< typename T >
+using array3d = LvArray::Array< int, 3, RAJA::PERM_IJK, int, LvArray::MallocBuffer >;
+template< typename T >
+using aoa = LvArray::ArrayOfArrays< T, int, LvArray::MallocBuffer >;
+
+
+int main()
+{
+  array1d< int > v0;
+
+  array1d< int > v1;
+  v1.emplace_back( 1 );
+  v1.emplace_back( 2 );
+
+  auto v1v = v1.toView();
+  LVARRAY_LOG( v1v[0] );
+  auto v1vc = v1.toViewConst();
+  LVARRAY_LOG( v1vc[0] );
+
+  array2d< int > v2( 2, 3 );
+  v2[0][0] = 1;
+  v2[0][1] = 2;
+  v2[0][2] = 3;
+  v2[1][0] = 4;
+  v2[1][1] = 5;
+  v2[1][2] = 6;
+
+  auto v2v = v2.toView();
+  LVARRAY_LOG( v2v[0][0] );
+  auto v2vc = v2.toViewConst();
+  LVARRAY_LOG( v2vc[0][0] );
+  auto v2s = v2[0];
+  LVARRAY_LOG( v2s[0] );
+  auto v2sc = v2[0].toSliceConst();
+  LVARRAY_LOG( v2sc[0] );
+
+  array3d< int > v3( 2, 3, 4 );
+  for( int i = 0, count = 0; i < 2; ++i )
+  {
+    for( int j = 0; j < 3; ++j )
+    {
+      for( int k = 0; k < 4; ++k, ++count )
+      {
+        v3[i][j][k] = count;
+      }
+    }
+  }
+
+  auto v3v = v3.toView();
+  LVARRAY_LOG( v3v[0][0][0] );
+  auto v3vc = v3.toViewConst();
+  LVARRAY_LOG( v3vc[0][0][0] );
+
+  auto v3s = v3[0];
+  LVARRAY_LOG( v3s[0][0] );
+  auto v3s2 = v3[0][0];
+  LVARRAY_LOG( v3s2[0] );
+
+  aoa< int > aoa0( 2, 10 );
+  aoa0.emplaceBack( 0, 1 );
+  aoa0.emplaceBack( 0, 2 );
+  aoa0.emplaceBack( 0, 3 );
+  aoa0.emplaceBack( 1, 7 );
+  aoa0.emplaceBack( 1, 8 );
+
+  auto aoa0v = aoa0.toView();
+  LVARRAY_LOG( aoa0v[0][0] );
+  auto aoa0vc = aoa0.toViewConst();
+  LVARRAY_LOG( aoa0vc[0][0] );
+
+  auto aoa0s = aoa0[1];
+  LVARRAY_LOG( aoa0s[0] );
+
+  breakpoint_helper();
+
+  return 0;
+}

--- a/unitTests/testPrettyPrinters.cpp
+++ b/unitTests/testPrettyPrinters.cpp
@@ -13,8 +13,8 @@ void breakpoint_helper()
 
 template< typename T >
 using array1d = LvArray::Array< int, 1, RAJA::PERM_I, int, LvArray::MallocBuffer >;
-template< typename T >
-using array2d = LvArray::Array< int, 2, RAJA::PERM_IJ, int, LvArray::MallocBuffer >;
+template< typename T, typename P = RAJA::PERM_IJ >
+using array2d = LvArray::Array< int, 2, P, int, LvArray::MallocBuffer >;
 template< typename T >
 using array3d = LvArray::Array< int, 3, RAJA::PERM_IJK, int, LvArray::MallocBuffer >;
 template< typename T >
@@ -41,6 +41,7 @@ int main()
   v2[1][0] = 4;
   v2[1][1] = 5;
   v2[1][2] = 6;
+  array2d< int, RAJA::PERM_JI > v2ji( 2, 3 );
 
   auto v2v = v2.toView();
   LVARRAY_LOG( v2v[0][0] );

--- a/unitTests/testPrettyPrinters.py
+++ b/unitTests/testPrettyPrinters.py
@@ -84,7 +84,7 @@ def test_pretty_printer(test_case: TestCase):
     src_dir: str = os.environ["LVARRAY_SRC_DIR"]  # Skip tedious CLI pytest configuration, see comments above.
     cli = ["/usr/bin/gdb",
            "-iex", f"source {os.path.join(src_dir, 'scripts/gdb-printers-shallow.py')}",
-           "-ex", "set width 300",  # I do not wan t the output to be polluted with carriage returns.
+           "-ex", "set width 300",  # I do not want the output to be polluted with carriage returns.
            "-ex", "set style enabled off",
            "-ex", "set verbose off",
            "-ex", "set confirm off",
@@ -95,7 +95,7 @@ def test_pretty_printer(test_case: TestCase):
            "-ex", "quit",
            test_case.executable]
     try:
-        # I'm using a simple `subprocess.run` because I can use define all the interactions I need
+        # I'm using a simple `subprocess.run` because I can define all the actions I need
         # through the `-ex` options of `gdb`. In the case something more complex would be needed,
         # it's possible to create a `subprocess.Popen`, to manage the `std{in,out,err}` as `subprocess.PIPE`,
         # and to send the information using `process.stdin.write("run\n")`.

--- a/unitTests/testPrettyPrinters.py
+++ b/unitTests/testPrettyPrinters.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass
+import logging
+import os
+import subprocess
+from typing import (
+    Any,
+    Iterable,
+)
+
+import pytest
+
+
+@dataclass(frozen=True)
+class TestCase:
+    __test__ = False
+    executable: str
+    cpp_var_name: str
+    expected: str
+    breakpoint: int | str = "breakpoint_helper"
+    timeout: int = 1
+
+
+def build_output_str(array_type: str, value_type: str, dimensions: tuple[Any, ...], values: tuple[Any, ...],
+                     permutation: tuple[Any, ...], buffer="MallocBuffer") -> str:
+    if array_type in ("ArrayOfArrays", "ArrayOfArraysView"):
+        shape_args = f"size {dimensions[0]}"
+        if array_type == "ArrayOfArrays":
+            template_args = f"{value_type}, int, LvArray::{buffer}"
+        elif array_type == "ArrayOfArraysView":
+            template_args = f"{value_type}, int const, {'true' if 'const' in value_type else 'false'}, LvArray::{buffer}"
+    else:
+        if "View" in array_type:
+            p = str(permutation[-1])
+        elif "Slice" in array_type:
+            p = len(dimensions) - 1
+        else:
+            p = f"camp::int_seq<long, {', '.join(map(str, permutation))}>"
+        template_args = f"{value_type}, {len(dimensions)}, {p}, int{', LvArray::' + buffer if not 'Slice' in array_type else ''}"
+        shape_args = f"shape [{', '.join(map(str, dimensions))}]"
+    result = f"LvArray::{array_type}<{template_args}> of {shape_args}"
+    if values:
+        v = str(values).replace('(', '{').replace(')', '}')
+        result += " = " + v
+    return result
+
+
+def generate_data() -> Iterable[TestCase]:
+    # Passing cli arguments to pytest is a bit complicated for the little use we make of it.
+    # Therefore, running the tests with `LVARRAY_SRC_DIR=/... LVARRAY_BUILD_DIR=/... python -m pytest`
+    # looks like a good compromise.
+    build_dir: str = os.environ["LVARRAY_BUILD_DIR"]
+    exe: str = os.path.join(build_dir, "tests/testPrettyPrinters")
+    # Empty vector
+    yield TestCase(exe, "v0", build_output_str("Array", "int", (0,), (), (0,)))
+    # 1d vectors
+    d, v, p = (2,), (1, 2), (0,)
+    yield TestCase(exe, "v1", build_output_str("Array", "int", d, v, p))
+    yield TestCase(exe, "v1v", build_output_str("ArrayView", "int", d, v, p))
+    yield TestCase(exe, "v1vc", build_output_str("ArrayView", "int const", d, v, p))
+    # 2d vectors
+    d, v, p = (2, 3), ((1, 2, 3), (4, 5, 6)), (0, 1)
+    yield TestCase(exe, "v2", build_output_str("Array", "int", d, v, p))
+    yield TestCase(exe, "v2v", build_output_str("ArrayView", "int", d, v, p))
+    yield TestCase(exe, "v2s", build_output_str("ArraySlice", "int", d[1:], v[0], p[:1]))
+    yield TestCase(exe, "v2sc", build_output_str("ArraySlice", "int const", d[1:], v[0], p[:1]))
+    # 3d vectors
+    d, p = (2, 3, 4), (0, 1, 2)
+    v = (((0, 1, 2, 3), (4, 5, 6, 7), (8, 9, 10, 11)), ((12, 13, 14, 15), (16, 17, 18, 19), (20, 21, 22, 23)))
+    yield TestCase(exe, "v3", build_output_str("Array", "int", d, v, p))
+    yield TestCase(exe, "v3v", build_output_str("ArrayView", "int", d, v, p))
+    yield TestCase(exe, "v3vc", build_output_str("ArrayView", "int const", d, v, p))
+    yield TestCase(exe, "v3s", build_output_str("ArraySlice", "int", d[1:], v[0], p[:1]))
+    yield TestCase(exe, "v3s2", build_output_str("ArraySlice", "int", d[2:], v[0][0], p[:2]))
+    # array of arrays
+    d, v, p = (2,), ((1, 2, 3), (7, 8)), (0,)
+    yield TestCase(exe, "aoa0", build_output_str("ArrayOfArrays", "int", d, v, p))
+    yield TestCase(exe, "aoa0v", build_output_str("ArrayOfArraysView", "int", d, v, p))
+    yield TestCase(exe, "aoa0vc", build_output_str("ArrayOfArraysView", "int const", d, v, p))
+    yield TestCase(exe, "aoa0s", build_output_str("ArraySlice", "int", d, v[1], p))
+
+
+@pytest.mark.parametrize("test_case", generate_data())
+def test_pretty_printer(test_case: TestCase):
+    src_dir: str = os.environ["LVARRAY_SRC_DIR"]  # Skip tedious CLI pytest configuration, see comments above.
+    cli = ["/usr/bin/gdb",
+           "-iex", f"source {os.path.join(src_dir, 'scripts/gdb-printers-shallow.py')}",
+           "-ex", "set width 300",  # I do not wan t the output to be polluted with carriage returns.
+           "-ex", "set style enabled off",
+           "-ex", "set verbose off",
+           "-ex", "set confirm off",
+           "-ex", f"break {test_case.breakpoint}",
+           "-ex", "run",
+           "-ex", "finish",
+           "-ex", f"print {test_case.cpp_var_name}",
+           "-ex", "quit",
+           test_case.executable]
+    try:
+        # I'm using a simple `subprocess.run` because I can use define all the interactions I need
+        # through the `-ex` options of `gdb`. In the case something more complex would be needed,
+        # it's possible to create a `subprocess.Popen`, to manage the `std{in,out,err}` as `subprocess.PIPE`,
+        # and to send the information using `process.stdin.write("run\n")`.
+        # Another more flexible approach would be to use Pexpect (https://github.com/pexpect/pexpect).
+        process = subprocess.run(cli, timeout=1, check=True, capture_output=True, text=True)
+        logging.debug(process.stdout, process.stderr)
+        assert test_case.expected in process.stdout
+    except subprocess.TimeoutExpired as e:
+        logging.error(e.stdout, e.stderr)
+        raise e
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Process \"{' '.join(cli)}\" exited with error code {process.returncode}.")
+        logging.error(e.stdout, e.stderr)
+        raise e

--- a/unitTests/testPrettyPrinters.py
+++ b/unitTests/testPrettyPrinters.py
@@ -77,6 +77,7 @@ def generate_data() -> Iterable[TestCase]:
     yield TestCase(exe, "aoa0v", build_output_str("ArrayOfArraysView", "int", d, v, p))
     yield TestCase(exe, "aoa0vc", build_output_str("ArrayOfArraysView", "int const", d, v, p))
     yield TestCase(exe, "aoa0s", build_output_str("ArraySlice", "int", d, v[1], p))
+    yield TestCase(exe, "v2ji", "Only sorted permutation is supported by pretty printers.")
 
 
 @pytest.mark.parametrize("test_case", generate_data())
@@ -102,7 +103,7 @@ def test_pretty_printer(test_case: TestCase):
         # Another more flexible approach would be to use Pexpect (https://github.com/pexpect/pexpect).
         process = subprocess.run(cli, timeout=1, check=True, capture_output=True, text=True)
         logging.debug(process.stdout, process.stderr)
-        assert test_case.expected in process.stdout
+        assert test_case.expected in process.stdout or test_case.expected in process.stderr
     except subprocess.TimeoutExpired as e:
         logging.error(e.stdout, e.stderr)
         raise e


### PR DESCRIPTION
I needed `LvArray` pretty printers that would match the `STL` pretty printers pattern.
This version of the pretty printers do not show any implementation details and focus on the sole data. As such I've simplifying the existing pretty printers a bit.

I've added unit tests, but I did not activate those unit tests through any CI/CD process (I think that this is another subject).