### PR TITLE
remove camp as a specific dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ set( lvarray_dependencies dl )
 
 blt_list_append( TO lvarray_dependencies ELEMENTS chai IF ENABLE_CHAI )
 
-blt_list_append( TO lvarray_dependencies ELEMENTS camp RAJA )
+blt_list_append( TO lvarray_dependencies ELEMENTS RAJA )
 
 blt_list_append( TO lvarray_dependencies ELEMENTS umpire IF ENABLE_UMPIRE )
 


### PR DESCRIPTION
remove camp as a specific dependency to avoid duplicate lib messages since it alreay is an inhertited dependency from RAJA