### PR TITLE
feat: Deduce access level in PyArrayWrapper from constness of given array reference

### DIFF
--- a/src/python/PyArray.hpp
+++ b/src/python/PyArray.hpp
@@ -142,12 +142,12 @@ public:
    * @param array The array to wrap.
    * @param accessLevel The access level (see PyModify).
    */
-  PyArrayWrapper( Array< T, NDIM, PERM, INDEX_TYPE, BUFFER_TYPE > & array, 
+  PyArrayWrapper( Array< T, NDIM, PERM, INDEX_TYPE, BUFFER_TYPE > & array,
                   int accessLevel = static_cast< int >( LvArray::python::PyModify::READ_ONLY )):
     PyArrayWrapperBase(),
     m_array( array )
   {
-    setAccessLevel(accessLevel, static_cast<int>(LvArray::MemorySpace::host));
+    setAccessLevel( accessLevel, static_cast< int >(LvArray::MemorySpace::host));
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -259,7 +259,7 @@ std::enable_if_t< internal::canExportToNumpy< T > || (std::is_same< T, std::stri
 create( Array< T, NDIM, PERM, INDEX_TYPE, BUFFER_TYPE > & array )
 {
   using WrapperType = internal::PyArrayWrapper< T, NDIM, PERM, INDEX_TYPE, BUFFER_TYPE >;
-  return internal::create( std::make_unique< WrapperType >( array, static_cast<int>(LvArray::python::PyModify::MODIFIABLE) ) );
+  return internal::create( std::make_unique< WrapperType >( array, static_cast< int >(LvArray::python::PyModify::MODIFIABLE) ) );
 }
 
 /**
@@ -279,7 +279,7 @@ std::enable_if_t< internal::canExportToNumpy< T > || (std::is_same< T, std::stri
 create( Array< T, NDIM, PERM, INDEX_TYPE, BUFFER_TYPE > const & array )
 {
   using WrapperType = internal::PyArrayWrapper< T, NDIM, PERM, INDEX_TYPE, BUFFER_TYPE >;
-  return internal::create( std::make_unique< WrapperType >( const_cast< Array< T, NDIM, PERM, INDEX_TYPE, BUFFER_TYPE > & >( array ), static_cast<int>(LvArray::python::PyModify::READ_ONLY) ) );
+  return internal::create( std::make_unique< WrapperType >( const_cast< Array< T, NDIM, PERM, INDEX_TYPE, BUFFER_TYPE > & >( array ), static_cast< int >(LvArray::python::PyModify::READ_ONLY) ) );
 }
 
 /**


### PR DESCRIPTION
This PR supports the construction of PyArrayWrapper with a MODIFIABLE access level. Before the access level was READ_ONLY by default. Now the access level is chosen based on the constness of the reference of the underlying Array.
It is convenient and allows to avoid the change of access level from Python in [GEOS: PR 3391](https://github.com/GEOS-DEV/GEOS/pull/3391). This is important to not add extra code to Python, because we are going to use the Python interface common between GEOS and open-darts.

We are going to use it in embedding of Python function in C++. In the example, the function has READ_ONLY first argument and MODIFIABLE second one, which we write to in Python. The example: [typedef](https://github.com/GEOS-DEV/GEOS/blob/c5c67f28ff1398ff4c31b177e09c547ae0b4ca74/src/coreComponents/functions/PythonFunction.hpp#L73) and [use](https://github.com/GEOS-DEV/GEOS/blob/c5c67f28ff1398ff4c31b177e09c547ae0b4ca74/src/coreComponents/functions/PythonFunction.hpp#L190) 