### PR TITLE
fix: build error on Lassen.

### DIFF
--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -206,7 +206,7 @@ bool invalidIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES con
 template< typename INDEX_TYPE, typename ... INDICES >
 LVARRAY_HOST_DEVICE inline
 void checkIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES const ... indices )
-{ LVARRAY_ERROR_IF( invalidIndices( dims, indices ... ), "Invalid indices. " << printDimsAndIndices( dims, indices ... ) ); }
+{ LVARRAY_ERROR_IF( false , "Invalid indices. " ); }
 
 /**
  * @brief Calculate the strides given the dimensions and permutation.

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -159,20 +159,40 @@ std::string getIndexString( INDEX const index, REMAINING_INDICES const ... indic
  * @param indices A variadic pack of indices.
  */
 template< typename INDEX_TYPE, typename ... INDICES >
-std::string printDimsAndIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES const... indices )
+LVARRAY_HOST_DEVICE
+void printDimsAndIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES const... indices )
 {
   constexpr int NDIM = sizeof ... (INDICES);
-  std::ostringstream oss;
-  oss << "dimensions = { " << dims[ 0 ];
+  printf( "dimensions = { %d", dims[ 0 ] );
   for( int i = 1; i < NDIM; ++i )
   {
-    oss << ", " << dims[ i ];
+    printf( ", %d", dims[ i ] );
   }
+  printf( "}\n");
 
-  oss << " } indices = " << getIndexString( indices ... );
-
-  return oss.str();
+  printf( "   indices = { " );
+  (printf(" %d, ", indices ),...);
+  printf( "}\n");
 }
+
+
+/**
+ * @brief Function to check if an index is invalid
+ * @tparam DIMS_TYPE The integral type used for the dimensions of the space
+ * @tparam INDEX_TYPE The Integral types of the index to check against 
+ * @param dims A pointer to the dimensions of the space.
+ * @param indices the index to check against.
+ * @return whether the index is invalid
+ */
+template< typename DIMS_TYPE, typename INDEX_TYPE >
+LVARRAY_HOST_DEVICE inline constexpr
+bool invalidIndex( DIMS_TYPE const * const LVARRAY_RESTRICT dims, 
+                   int const dimsIndex,
+                   INDEX_TYPE const index )
+{
+  return (index < 0) || (index >= dims[dimsIndex]);
+}
+
 
 /**
  * @tparam INDEX_TYPE The integral type used for the dimensions of the space.
@@ -185,14 +205,9 @@ template< typename INDEX_TYPE, typename ... INDICES >
 LVARRAY_HOST_DEVICE inline constexpr
 bool invalidIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES const ... indices )
 {
-  int curDim = 0;
   bool invalid = false;
-  typeManipulation::forEachArg( [dims, &curDim, &invalid]( auto const index )
-  {
-    invalid = invalid || ( index < 0 ) || ( index >= dims[ curDim ] );
-    ++curDim;
-  }, indices ... );
-
+  int curDim = 0;
+  (invalidIndex(dims, curDim++, indices),...);
   return invalid;
 }
 
@@ -206,7 +221,14 @@ bool invalidIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES con
 template< typename INDEX_TYPE, typename ... INDICES >
 LVARRAY_HOST_DEVICE inline
 void checkIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES const ... indices )
-{ LVARRAY_ERROR_IF( false , "Invalid indices. " ); }
+{ 
+  bool const invalid = invalidIndices( dims, indices ... );
+  if( invalid )
+  {
+    printDimsAndIndices( dims, indices ... );
+    LVARRAY_ERROR( "Invalid indices. Info precedes this line." ); 
+  }
+}
 
 /**
  * @brief Calculate the strides given the dimensions and permutation.

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -160,7 +160,7 @@ LVARRAY_HOST_DEVICE
 void printIndexValue( INDEX_TYPE const & val )
 {
   using DecayedType = std::decay_t<INDEX_TYPE>;
-  static_assert( std::is_integral_v< DecayedType >, "INDEX_TYPE must be an integral type." );
+  // static_assert( std::is_integral_v< DecayedType >, "INDEX_TYPE must be an integral type." );
 
   if constexpr( std::is_same_v<DecayedType, int> )
   {
@@ -194,9 +194,25 @@ void printIndexValue( INDEX_TYPE const & val )
   {
     printf( "%hu", val );
   }
+  else if constexpr( std::is_same_v<DecayedType, char> )
+  {
+    printf( "%c", val );
+  }
+  else if constexpr( std::is_same_v<DecayedType, signed char> )
+  {
+    printf( "%hhd", val );
+  }
+  else if constexpr( std::is_same_v<DecayedType, unsigned char> )
+  {
+    printf( "%hhu", val );
+  }
+  else if constexpr( std::is_same_v<DecayedType, bool> )
+  {
+    printf( "%d", val );
+  }
   else
   {
-    printf( "%llu", static_cast< long long>( val ) );
+    printf( "%lld", static_cast< long long >( val ) );
   }
 }
 

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -153,7 +153,10 @@ std::string getIndexString( INDEX const index, REMAINING_INDICES const ... indic
   return oss.str();
 }
 
-
+/**
+ * @tparam INDEX_TYPE The integral type to be printed.
+ * @param val the value to be printed
+ */
 template< typename INDEX_TYPE >
 LVARRAY_HOST_DEVICE
 void printIndexValue( INDEX_TYPE const & val )

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -193,22 +193,22 @@ void printIndexValue( INDEX_TYPE const & val )
   {
     printf( "%hu", val );
   }
-  // else if constexpr( std::is_same_v<INDEX_TYPE, char> )
-  // {
-  //   printf( "%c", val );
-  // }
-  // else if constexpr( std::is_same_v<INDEX_TYPE, signed char> )
-  // {
-  //   printf( "%hhd", val );
-  // }
-  // else if constexpr( std::is_same_v<INDEX_TYPE, unsigned char> )
-  // {
-  //   printf( "%hhu", val );
-  // }
-  // else if constexpr( std::is_same_v<INDEX_TYPE, bool> )
-  // {
-  //   printf( "%d", val );
-  // }
+  else if constexpr( std::is_same_v<INDEX_TYPE, char> )
+  {
+    printf( "%c", val );
+  }
+  else if constexpr( std::is_same_v<INDEX_TYPE, signed char> )
+  {
+    printf( "%hhd", val );
+  }
+  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned char> )
+  {
+    printf( "%hhu", val );
+  }
+  else if constexpr( std::is_same_v<INDEX_TYPE, bool> )
+  {
+    printf( "%d", val );
+  }
   else
   {
     static_assert(!sizeof(INDEX_TYPE*), "Unsupported integral type for printIndexValue");

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -152,56 +152,6 @@ std::string getIndexString( INDEX const index, REMAINING_INDICES const ... indic
 }
 
 /**
- * @tparam INDEX_TYPE The integral type to be printed.
- * @param val the value to be printed
- */
-template< typename INDEX_TYPE >
-LVARRAY_HOST_DEVICE
-void printIndexValue( INDEX_TYPE const & val )
-{
-  /// NOTE: the assert is removed because of an error on one of the GEOS CI jobs.
-  // using DecayedType = std::decay_t<INDEX_TYPE>;
-  // static_assert( std::is_integral_v< DecayedType >, "INDEX_TYPE must be an integral type." );
-
-  if constexpr( std::is_same_v<INDEX_TYPE, int> )
-  {
-    printf( "%d", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned int> )
-  {
-    printf( "%u", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, long> )
-  {
-    printf( "%ld", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned long> )
-  {
-    printf( "%lu", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, long long> )
-  {
-    printf( "%lld", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned long long> )
-  {
-    printf( "%llu", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, short> )
-  {
-    printf( "%hd", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned short> )
-  {
-    printf( "%hu", val );
-  }
-  else
-  {
-    printf( "%lld", static_cast< long long >( val ) );
-  }
-}
-
-/**
  * @tparam INDEX_TYPE The integral type of the dimensions.
  * @tparam INDICES A variadic pack of the integral types of the indices.
  * @return A string representing the dimensions of the multidimensional space and the indices into it.
@@ -213,33 +163,31 @@ LVARRAY_HOST_DEVICE
 void printDimsAndIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES const... indices )
 {
   constexpr int NDIM = sizeof ... (INDICES);
-  printf( "dimensions = { ");
+  printf( "dimensions = { " );
   printIndexValue( dims[0] );
   for( int i = 1; i < NDIM; ++i )
   {
-    printf( ", ");
-    printIndexValue(dims[i]);
+    printf( ", %lld", static_cast< long long >( dims[ i ] ));
   }
-  printf( "}\n");
-  
-  printf( "indices = { ");
-  bool firstIndex = true;
-  ( (firstIndex ? ( firstIndex = false, printIndexValue(indices) ) : (printf(", "), printIndexValue(indices))), ...);
-  printf(" }\n");
+  printf( "}\n" );
+
+  printf( "indices = { " );
+  (printf( ", %lld", static_cast< long long >(indices)), ...);
+  printf( "}\n" );
 }
 
 
 /**
  * @brief Function to check if an index is invalid
  * @tparam DIMS_TYPE The integral type used for the dimensions of the space
- * @tparam INDEX_TYPE The Integral types of the index to check against 
+ * @tparam INDEX_TYPE The Integral types of the index to check against
  * @param dims A pointer to the dimensions of the space.
  * @param indices the index to check against.
  * @return whether the index is invalid
  */
 template< typename DIMS_TYPE, typename INDEX_TYPE >
 LVARRAY_HOST_DEVICE inline constexpr
-bool invalidIndex( DIMS_TYPE const * const LVARRAY_RESTRICT dims, 
+bool invalidIndex( DIMS_TYPE const * const LVARRAY_RESTRICT dims,
                    int const dimsIndex,
                    INDEX_TYPE const index )
 {
@@ -260,7 +208,7 @@ bool invalidIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES con
 {
   bool invalid = false;
   int curDim = 0;
-  ( (invalid = invalid || invalidIndex(dims, curDim++, indices)), ...);
+  ( (invalid = invalid || invalidIndex( dims, curDim++, indices )), ...);
   return invalid;
 }
 
@@ -274,12 +222,12 @@ bool invalidIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES con
 template< typename INDEX_TYPE, typename ... INDICES >
 LVARRAY_HOST_DEVICE inline
 void checkIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES const ... indices )
-{ 
+{
   bool const invalid = invalidIndices( dims, indices ... );
   if( invalid )
   {
     printDimsAndIndices( dims, indices ... );
-    LVARRAY_ERROR( "Invalid indices. Info precedes this line." ); 
+    LVARRAY_ERROR( "Invalid indices. Info precedes this line." );
   }
 }
 

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -159,59 +159,44 @@ template< typename INDEX_TYPE >
 LVARRAY_HOST_DEVICE
 void printIndexValue( INDEX_TYPE const & val )
 {
-  static_assert( std::is_integral_v< INDEX_TYPE >, "INDEX_TYPE must be an integral type." );
+  using DecayedType = std::decay_t<INDEX_TYPE>;
+  static_assert( std::is_integral_v< DecayedType >, "INDEX_TYPE must be an integral type." );
 
-  if constexpr( std::is_same_v<INDEX_TYPE, int> )
+  if constexpr( std::is_same_v<DecayedType, int> )
   {
     printf( "%d", val );
   }
-  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned int> )
+  else if constexpr( std::is_same_v<DecayedType, unsigned int> )
   {
     printf( "%u", val );
   }
-  else if constexpr( std::is_same_v<INDEX_TYPE, long> )
+  else if constexpr( std::is_same_v<DecayedType, long> )
   {
     printf( "%ld", val );
   }
-  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned long> )
+  else if constexpr( std::is_same_v<DecayedType, unsigned long> )
   {
     printf( "%lu", val );
   }
-  else if constexpr( std::is_same_v<INDEX_TYPE, long long> )
+  else if constexpr( std::is_same_v<DecayedType, long long> )
   {
     printf( "%lld", val );
   }
-  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned long long> )
+  else if constexpr( std::is_same_v<DecayedType, unsigned long long> )
   {
     printf( "%llu", val );
   }
-  else if constexpr( std::is_same_v<INDEX_TYPE, short> )
+  else if constexpr( std::is_same_v<DecayedType, short> )
   {
     printf( "%hd", val );
   }
-  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned short> )
+  else if constexpr( std::is_same_v<DecayedType, unsigned short> )
   {
     printf( "%hu", val );
   }
-  else if constexpr( std::is_same_v<INDEX_TYPE, char> )
-  {
-    printf( "%c", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, signed char> )
-  {
-    printf( "%hhd", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned char> )
-  {
-    printf( "%hhu", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, bool> )
-  {
-    printf( "%d", val );
-  }
   else
   {
-    static_assert(!sizeof(INDEX_TYPE*), "Unsupported integral type for printIndexValue");
+    static_assert(!sizeof(DecayedType*), "Unsupported integral type for printIndexValue");
   }
 }
 

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -159,54 +159,55 @@ template< typename INDEX_TYPE >
 LVARRAY_HOST_DEVICE
 void printIndexValue( INDEX_TYPE const & val )
 {
-  using DecayedType = std::decay_t<INDEX_TYPE>;
+  /// NOTE: the assert is removed because of an error on one of the GEOS CI jobs.
+  // using DecayedType = std::decay_t<INDEX_TYPE>;
   // static_assert( std::is_integral_v< DecayedType >, "INDEX_TYPE must be an integral type." );
 
-  if constexpr( std::is_same_v<DecayedType, int> )
+  if constexpr( std::is_same_v<INDEX_TYPE, int> )
   {
     printf( "%d", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, unsigned int> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned int> )
   {
     printf( "%u", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, long> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, long> )
   {
     printf( "%ld", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, unsigned long> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned long> )
   {
     printf( "%lu", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, long long> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, long long> )
   {
     printf( "%lld", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, unsigned long long> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned long long> )
   {
     printf( "%llu", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, short> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, short> )
   {
     printf( "%hd", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, unsigned short> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned short> )
   {
     printf( "%hu", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, char> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, char> )
   {
     printf( "%c", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, signed char> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, signed char> )
   {
     printf( "%hhd", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, unsigned char> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned char> )
   {
     printf( "%hhu", val );
   }
-  else if constexpr( std::is_same_v<DecayedType, bool> )
+  else if constexpr( std::is_same_v<INDEX_TYPE, bool> )
   {
     printf( "%d", val );
   }

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -161,14 +161,6 @@ void printIndexValue( INDEX_TYPE const & val )
 {
   static_assert( std::is_integral_v< INDEX_TYPE >, "INDEX_TYPE must be an integral type." );
 
-  static_assert( std::is_same_v<INDEX_TYPE, int> ||
-                 std::is_same_v<INDEX_TYPE, unsigned int> ||
-                 std::is_same_v<INDEX_TYPE, long> ||
-                 std::is_same_v<INDEX_TYPE, unsigned long> ||
-                 std::is_same_v<INDEX_TYPE, long long> ||
-                 std::is_same_v<INDEX_TYPE, short>, "Unsupported integral type for printIndexValue" );
-
-
   if constexpr( std::is_same_v<INDEX_TYPE, int> )
   {
     printf( "%d", val );
@@ -189,10 +181,34 @@ void printIndexValue( INDEX_TYPE const & val )
   {
     printf( "%lld", val );
   }
+  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned long long> )
+  {
+    printf( "%llu", val );
+  }
   else if constexpr( std::is_same_v<INDEX_TYPE, short> )
   {
     printf( "%hd", val );
   }
+  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned short> )
+  {
+    printf( "%hu", val );
+  }
+  // else if constexpr( std::is_same_v<INDEX_TYPE, char> )
+  // {
+  //   printf( "%c", val );
+  // }
+  // else if constexpr( std::is_same_v<INDEX_TYPE, signed char> )
+  // {
+  //   printf( "%hhd", val );
+  // }
+  // else if constexpr( std::is_same_v<INDEX_TYPE, unsigned char> )
+  // {
+  //   printf( "%hhu", val );
+  // }
+  // else if constexpr( std::is_same_v<INDEX_TYPE, bool> )
+  // {
+  //   printf( "%d", val );
+  // }
   else
   {
     static_assert(!sizeof(INDEX_TYPE*), "Unsupported integral type for printIndexValue");

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -20,6 +20,8 @@
 // TPL includes
 #include <RAJA/RAJA.hpp>
 
+#include <inttypes.h>
+
 namespace LvArray
 {
 
@@ -151,6 +153,29 @@ std::string getIndexString( INDEX const index, REMAINING_INDICES const ... indic
   return oss.str();
 }
 
+
+template< typename INDEX_TYPE >
+LVARRAY_HOST_DEVICE
+void printIndexValue( INDEX_TYPE const & val )
+{
+  if constexpr( std::is_same_v<INDEX_TYPE, int> )
+  {
+    printf( "%d", val );
+  }
+  else if constexpr( std::is_same_v<INDEX_TYPE, long> )
+  {
+    printf( "%ld", val );
+  }
+  else if constexpr( std::is_same_v<INDEX_TYPE, long long> )
+  {
+    printf( "%lld", val );
+  }
+  else
+  {
+    static_assert(!sizeof(T*), "Unsupported integral type for print_value");
+  }
+}
+
 /**
  * @tparam INDEX_TYPE The integral type of the dimensions.
  * @tparam INDICES A variadic pack of the integral types of the indices.
@@ -163,16 +188,19 @@ LVARRAY_HOST_DEVICE
 void printDimsAndIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES const... indices )
 {
   constexpr int NDIM = sizeof ... (INDICES);
-  printf( "dimensions = { %d", dims[ 0 ] );
+  printf( "dimensions = { ");
+  printIndexValue( dims[0] );
   for( int i = 1; i < NDIM; ++i )
   {
-    printf( ", %d", dims[ i ] );
+    printf( ", ");
+    printIndexValue(dims[i]);
   }
   printf( "}\n");
-
-  printf( "   indices = { " );
-  (printf(" %d, ", indices ),...);
-  printf( "}\n");
+  
+  printf( "indices = { ");
+  bool firstIndex = true;
+  ( (firstIndex ? ( firstIndex = false, printIndexValue(indices) ) : (printf(", "), printIndexValue(indices))), ...);
+  printf(" }\n");
 }
 
 

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -161,17 +161,31 @@ template< typename INDEX_TYPE >
 LVARRAY_HOST_DEVICE
 void printIndexValue( INDEX_TYPE const & val )
 {
+  static_assert( std::is_integral_v< INDEX_TYPE >, "INDEX_TYPE must be an integral type." );
+  
   if constexpr( std::is_same_v<INDEX_TYPE, int> )
   {
     printf( "%d", val );
+  }
+  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned int> )
+  {
+    printf( "%u", val );
   }
   else if constexpr( std::is_same_v<INDEX_TYPE, long> )
   {
     printf( "%ld", val );
   }
+  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned long> )
+  {
+    printf( "%lu", val );
+  }
   else if constexpr( std::is_same_v<INDEX_TYPE, long long> )
   {
     printf( "%lld", val );
+  }
+  else if constexpr( std::is_same_v<INDEX_TYPE, short> )
+  {
+    printf( "%hd", val );
   }
   else
   {

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -196,7 +196,7 @@ void printIndexValue( INDEX_TYPE const & val )
   }
   else
   {
-    static_assert(!sizeof(DecayedType*), "Unsupported integral type for printIndexValue");
+    printf( "%llu", static_cast< long long>( val ) );
   }
 }
 

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -195,22 +195,6 @@ void printIndexValue( INDEX_TYPE const & val )
   {
     printf( "%hu", val );
   }
-  else if constexpr( std::is_same_v<INDEX_TYPE, char> )
-  {
-    printf( "%c", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, signed char> )
-  {
-    printf( "%hhd", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, unsigned char> )
-  {
-    printf( "%hhu", val );
-  }
-  else if constexpr( std::is_same_v<INDEX_TYPE, bool> )
-  {
-    printf( "%d", val );
-  }
   else
   {
     printf( "%lld", static_cast< long long >( val ) );

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -172,7 +172,7 @@ void printIndexValue( INDEX_TYPE const & val )
   }
   else
   {
-    static_assert(!sizeof(T*), "Unsupported integral type for print_value");
+    static_assert(!sizeof(T*), "Unsupported integral type for printIndexValue");
   }
 }
 

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -175,7 +175,7 @@ void printIndexValue( INDEX_TYPE const & val )
   }
   else
   {
-    static_assert(!sizeof(T*), "Unsupported integral type for printIndexValue");
+    static_assert(!sizeof(INDEX_TYPE*), "Unsupported integral type for printIndexValue");
   }
 }
 

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -163,8 +163,7 @@ LVARRAY_HOST_DEVICE
 void printDimsAndIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES const... indices )
 {
   constexpr int NDIM = sizeof ... (INDICES);
-  printf( "dimensions = { " );
-  printIndexValue( dims[0] );
+  printf( "dimensions = { %lld", static_cast< long long >( dims[ 0 ] ) );
   for( int i = 1; i < NDIM; ++i )
   {
     printf( ", %lld", static_cast< long long >( dims[ i ] ));

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -20,8 +20,6 @@
 // TPL includes
 #include <RAJA/RAJA.hpp>
 
-#include <inttypes.h>
-
 namespace LvArray
 {
 
@@ -162,7 +160,15 @@ LVARRAY_HOST_DEVICE
 void printIndexValue( INDEX_TYPE const & val )
 {
   static_assert( std::is_integral_v< INDEX_TYPE >, "INDEX_TYPE must be an integral type." );
-  
+
+  static_assert( std::is_same_v<INDEX_TYPE, int> ||
+                 std::is_same_v<INDEX_TYPE, unsigned int> ||
+                 std::is_same_v<INDEX_TYPE, long> ||
+                 std::is_same_v<INDEX_TYPE, unsigned long> ||
+                 std::is_same_v<INDEX_TYPE, long long> ||
+                 std::is_same_v<INDEX_TYPE, short>, "Unsupported integral type for printIndexValue" );
+
+
   if constexpr( std::is_same_v<INDEX_TYPE, int> )
   {
     printf( "%d", val );

--- a/src/indexing.hpp
+++ b/src/indexing.hpp
@@ -207,7 +207,7 @@ bool invalidIndices( INDEX_TYPE const * const LVARRAY_RESTRICT dims, INDICES con
 {
   bool invalid = false;
   int curDim = 0;
-  (invalidIndex(dims, curDim++, indices),...);
+  ( (invalid = invalid || invalidIndex(dims, curDim++, indices)), ...);
   return invalid;
 }
 

--- a/src/typeManipulation.hpp
+++ b/src/typeManipulation.hpp
@@ -124,10 +124,12 @@ namespace typeManipulation
  * @param f The function to not call.
  */
 DISABLE_HD_WARNING
-template< typename F >
+template< typename F, typename ARG >
 inline constexpr LVARRAY_HOST_DEVICE
-void forEachArg( F && f )
-{ LVARRAY_UNUSED_VARIABLE( f ); }
+void forEachArg( F && f, ARG && arg )
+{ 
+  f(arg); 
+}
 
 /**
  * @tparam F The type of the function to call.

--- a/src/typeManipulation.hpp
+++ b/src/typeManipulation.hpp
@@ -549,9 +549,5 @@ LVARRAY_HOST_DEVICE inline constexpr
 CArray< camp::idx_t, sizeof...( INDICES ) > asArray( camp::idx_seq< INDICES... > )
 { return { INDICES ... }; }
 
-
-
-
-
 } // namespace typeManipulation
 } // namespace LvArray

--- a/src/typeManipulation.hpp
+++ b/src/typeManipulation.hpp
@@ -124,12 +124,10 @@ namespace typeManipulation
  * @param f The function to not call.
  */
 DISABLE_HD_WARNING
-template< typename F, typename ARG >
+template< typename F >
 inline constexpr LVARRAY_HOST_DEVICE
-void forEachArg( F && f, ARG && arg )
-{ 
-  f(arg); 
-}
+void forEachArg( F && f )
+{ LVARRAY_UNUSED_VARIABLE( f ); }
 
 /**
  * @tparam F The type of the function to call.

--- a/src/typeManipulation.hpp
+++ b/src/typeManipulation.hpp
@@ -549,5 +549,9 @@ LVARRAY_HOST_DEVICE inline constexpr
 CArray< camp::idx_t, sizeof...( INDICES ) > asArray( camp::idx_seq< INDICES... > )
 { return { INDICES ... }; }
 
+
+
+
+
 } // namespace typeManipulation
 } // namespace LvArray


### PR DESCRIPTION
On Lassen when building on Debug with cuda11 (any compiler) the following error shows up:

```c++
/usr/WS2/cusini1/geos/GEOS/src/coreComponents/LvArray/src/indexing.hpp(194): error: calling a __host__ function("std::basic_ios<char,     ::std::char_traits<char> > ::~basic_ios()") from a __host__ __device__ function("std::basic_ios<char,     ::std::char_traits<char> > ::~basic_ios [subobject]") is not allowed

/usr/WS2/cusini1/geos/GEOS/src/coreComponents/LvArray/src/indexing.hpp(194): error: calling a __host__ function("std::basic_ios<char,     ::std::char_traits<char> > ::basic_ios()") from a __host__ __device__ function("std::basic_ios<char,     ::std::char_traits<char> > ::basic_ios [subobject]") is not allowed

2 errors detected in the compilation of "/usr/WS2/cusini1/geos/GEOS/src/coreComponents/mesh/FaceElementSubRegion.cpp".
``` 

The error seems to originate in `LvArray` indexing so I have tried to figure out what was triggering it. This PR is here to keep track of my attempts. 

@corbett5 @wrtobin @rrsettgast help is welcome. 