### PR TITLE
Update RAJA suite to v2025.03.0

### DIFF
--- a/host-configs/LLNL/llnl-tpls-base.cmake
+++ b/host-configs/LLNL/llnl-tpls-base.cmake
@@ -1,2 +1,2 @@
 set(GEOS_TPL_ROOT_DIR /usr/gapps/GEOSX/thirdPartyLibs CACHE PATH "")
-set(GEOS_TPL_DIR ${GEOS_TPL_ROOT_DIR}/2024-12-06/install-${CONFIG_NAME}-release CACHE PATH "")
+set(GEOS_TPL_DIR ${GEOS_TPL_ROOT_DIR}/2025-04-02_tplMirror/install-${CONFIG_NAME}-release CACHE PATH "")

--- a/host-configs/LLNL/lvarray-dane-toss_4_x86_64_ib-gcc@12.1.1.cmake
+++ b/host-configs/LLNL/lvarray-dane-toss_4_x86_64_ib-gcc@12.1.1.cmake
@@ -33,15 +33,15 @@ set(ENABLE_CUDA OFF CACHE BOOL "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-iev43uxnll3jsod7jloak5iwmox6owlv" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/dane-gcc-12_tpls/gcc-12.1.1/chai-git.4b9060b18b9bec1167026cfb3132bd540c4bd56b_develop-uq6ogpe5shfs5s5ifayx27gvzm3n3xcf" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-ikig7gipi7bsuxopxfac7uvrup3kd4rx" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/dane-gcc-12_tpls/gcc-12.1.1/raja-git.1d70abf171474d331f1409908bdf1b1c3fe19222_develop-37yxlbkfjq4ww4iw46u3a3d52oi6pul4" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-4t7pxjbfakzclltrwpajtryfkntshmwu" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/dane-gcc-12_tpls/gcc-12.1.1/umpire-git.1ed0669c57f041baa1f1070693991c3a7a43e7ee_develop-tymd742qkyap4m2m3kcnlx4mqnikk4pw" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-fv2sc4dnl7tma5k3wpu5r2tgcinfpz7u" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/dane-gcc-12_tpls/gcc-12.1.1/camp-git.ee0a3069a7ae72da8bcea63c06260fad34901d43_main-wtxnzy3oakj4hdtuj5vpwpdtymqmyt4s" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -49,9 +49,9 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-bno6d6qyyvivznkozzdh27ljrj3yqbv2" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/dane-gcc-12_tpls/gcc-12.1.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-bno6d6qyyvivznkozzdh27ljrj3yqbv2" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/adiak-0.4.0-dimwte7ij4naho6hhcqowidlxnespn7e/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/dane-gcc-12_tpls/gcc-12.1.1/adiak-0.4.0-dimwte7ij4naho6hhcqowidlxnespn7e/lib/cmake/adiak" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Documentation
@@ -59,7 +59,7 @@ set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-1
 
 set(SPHINX_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/python/quartz-gcc-python/python/bin/sphinx-build" CACHE PATH "")
 
-set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/doxygen-1.8.20-hbxmvlkrwmpt5mvibhths6cdo5rlor3s/bin/doxygen" CACHE PATH "")
+set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/dane-gcc-12_tpls/gcc-12.1.1/doxygen-1.8.20-hbxmvlkrwmpt5mvibhths6cdo5rlor3s/bin/doxygen" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Development tools

--- a/host-configs/LLNL/lvarray-lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1-cuda@11.8.0.cmake
+++ b/host-configs/LLNL/lvarray-lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1-cuda@11.8.0.cmake
@@ -3,7 +3,7 @@
 #################################################################################
 #--------------------------------------------------------------------------------
 # SYS_TYPE: blueos_3_ppc64le_ib_p9
-# Compiler Spec: gcc@=8.3.1
+# Compiler Spec: clang@=10.0.1
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #--------------------------------------------------------------------------------
 
@@ -11,9 +11,9 @@
 # Compilers
 #--------------------------------------------------------------------------------
 
-set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-10.0.1-gcc-8.3.1/bin/clang" CACHE PATH "")
 
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/g++" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-10.0.1-gcc-8.3.1/bin/clang++" CACHE PATH "")
 
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG" CACHE STRING "")
 
@@ -49,15 +49,15 @@ set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-jvnmbz3nfrjym77m2m2ddxfgyigf2hqv" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-10-cuda-11_tpls/clang-10.0.1/chai-git.4b9060b18b9bec1167026cfb3132bd540c4bd56b_develop-77slff2jnddra4feyt64f23fza2x6eeh" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-ktim3j27la76tmlr6ryj2vjfllltmz4o" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-10-cuda-11_tpls/clang-10.0.1/raja-git.1d70abf171474d331f1409908bdf1b1c3fe19222_develop-4g4qjxcaas7stqgc5ilday63r5557jf2" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-xmi5nbcsff7dz76ljlmr5catjxa4hzjn" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-10-cuda-11_tpls/clang-10.0.1/umpire-git.1ed0669c57f041baa1f1070693991c3a7a43e7ee_develop-oxerfmieb5y5mu6mutrl2syxmo3jxwsa" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-d4ymmapzrvlzw6jwjiyenqd5l2sy7pg7" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-10-cuda-11_tpls/clang-10.0.1/camp-git.ee0a3069a7ae72da8bcea63c06260fad34901d43_main-qaxwkoxoc7xcuz6zdzjobll4mst7ia4a" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -65,9 +65,9 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tp
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-rw6xo4fv4xn4oapuiypwwn7cz3m73naz" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-10-cuda-11_tpls/clang-10.0.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-xiwon23mamhn2tkcnqks5crznnqaovjt" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/adiak-0.4.0-n3yugcwz5o3ggvi2nrwybgmfattinedh/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-10-cuda-11_tpls/clang-10.0.1/adiak-0.4.0-tp3jxzzp7ifbreg2erbvusm34w64jau7/lib/cmake/adiak" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Documentation

--- a/host-configs/LLNL/lvarray-lassen-blueos_3_ppc64le_ib_p9-clang@13.0.1-cuda@11.8.0.cmake
+++ b/host-configs/LLNL/lvarray-lassen-blueos_3_ppc64le_ib_p9-clang@13.0.1-cuda@11.8.0.cmake
@@ -29,7 +29,7 @@ set(ENABLE_CUDA ON CACHE BOOL "")
 
 set(CMAKE_CUDA_STANDARD "17" CACHE PATH "")
 
-set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-12.0.0" CACHE PATH "")
+set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-11.8.0" CACHE PATH "")
 
 set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
 
@@ -49,15 +49,15 @@ set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-nmmjzxisecb5fpqfnvsm7q25riyc4v6n" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-11_tpls/clang-13.0.1/chai-git.4b9060b18b9bec1167026cfb3132bd540c4bd56b_develop-lz73muq6zmypwpywbnpqqdnywhsidjqm" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-54zp6bxl3yepw3nh3awk455q22vakj2u" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-11_tpls/clang-13.0.1/raja-git.1d70abf171474d331f1409908bdf1b1c3fe19222_develop-3foeh6gkykzpt3kejqctn2npqwv2wqvy" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-ztjsbkdojxcrgqnqrkvm7wq5oz4lm7cw" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-11_tpls/clang-13.0.1/umpire-git.1ed0669c57f041baa1f1070693991c3a7a43e7ee_develop-dwxqiqok2v7es3aw3orqzy77egrl6w37" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-fs7yeokq6dq3pql5hndzczn36ykkfhon" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-11_tpls/clang-13.0.1/camp-git.ee0a3069a7ae72da8bcea63c06260fad34901d43_main-pzehynwfhbfuscddfvttoqedvx4wcxjl" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -65,9 +65,9 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-4gu3btnlno2sbv56vhd3ux2uvgoupkgi" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-11_tpls/clang-13.0.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-4gu3btnlno2sbv56vhd3ux2uvgoupkgi" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/adiak-0.4.0-hqwcvthhjo5zs4b3u52glnlcxk5bp34n/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-11_tpls/clang-13.0.1/adiak-0.4.0-hqwcvthhjo5zs4b3u52glnlcxk5bp34n/lib/cmake/adiak" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Documentation

--- a/host-configs/LLNL/lvarray-lassen-blueos_3_ppc64le_ib_p9-clang@13.0.1-cuda@12.0.0.cmake
+++ b/host-configs/LLNL/lvarray-lassen-blueos_3_ppc64le_ib_p9-clang@13.0.1-cuda@12.0.0.cmake
@@ -1,0 +1,89 @@
+#################################################################################
+# Generated host-config - Edit at own risk!
+#################################################################################
+#--------------------------------------------------------------------------------
+# SYS_TYPE: blueos_3_ppc64le_ib_p9
+# Compiler Spec: clang@=13.0.1
+# CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Compilers
+#--------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-13.0.1-gcc-8.3.1/bin/clang" CACHE PATH "")
+
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-13.0.1-gcc-8.3.1/bin/clang++" CACHE PATH "")
+
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG" CACHE STRING "")
+
+set(CMAKE_CXX_FLAGS_DEBUG "-g" CACHE STRING "")
+
+#--------------------------------------------------------------------------------
+# Cuda
+#--------------------------------------------------------------------------------
+
+set(ENABLE_CUDA ON CACHE BOOL "")
+
+set(CMAKE_CUDA_STANDARD "17" CACHE PATH "")
+
+set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-12.0.0" CACHE PATH "")
+
+set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
+
+set(CMAKE_CUDA_ARCHITECTURES "70" CACHE STRING "")
+
+set(CMAKE_CUDA_FLAGS "-restrict --expt-extended-lambda -Werror cross-execution-space-call,reorder,deprecated-declarations -arch sm_70" CACHE STRING "")
+
+set(CMAKE_CUDA_FLAGS_RELEASE "-O3 -DNDEBUG -Xcompiler -DNDEBUG -Xcompiler -O3 -Xcompiler -mcpu=powerpc64le -Xcompiler -mtune=powerpc64le" CACHE STRING "")
+
+set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-g -lineinfo ${CMAKE_CUDA_FLAGS_RELEASE}" CACHE STRING "")
+
+set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
+
+#--------------------------------------------------------------------------------
+# Performance Portability TPLs
+#--------------------------------------------------------------------------------
+
+set(ENABLE_CHAI ON CACHE BOOL "")
+
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-12_tpls/clang-13.0.1/chai-git.4b9060b18b9bec1167026cfb3132bd540c4bd56b_develop-cj6qdra5ki4cv4v7rdmyxe6yc2ob4yo3" CACHE PATH "")
+
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-12_tpls/clang-13.0.1/raja-git.1d70abf171474d331f1409908bdf1b1c3fe19222_develop-7g5ad7lnurgi7zvdpjwvsstrnatz3dhv" CACHE PATH "")
+
+set(ENABLE_UMPIRE ON CACHE BOOL "")
+
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-12_tpls/clang-13.0.1/umpire-git.1ed0669c57f041baa1f1070693991c3a7a43e7ee_develop-z6qtq6uggxscyn6jckjewzzyaxgsojvd" CACHE PATH "")
+
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-12_tpls/clang-13.0.1/camp-git.ee0a3069a7ae72da8bcea63c06260fad34901d43_main-zseh26hvunbp5hdce5akbstmvp7ie5ka" CACHE PATH "")
+
+#--------------------------------------------------------------------------------
+# IO TPLs
+#--------------------------------------------------------------------------------
+
+set(ENABLE_CALIPER ON CACHE BOOL "")
+
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-12_tpls/clang-13.0.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-4gu3btnlno2sbv56vhd3ux2uvgoupkgi" CACHE PATH "")
+
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-clang-13-cuda-12_tpls/clang-13.0.1/adiak-0.4.0-hqwcvthhjo5zs4b3u52glnlcxk5bp34n/lib/cmake/adiak" CACHE PATH "")
+
+#--------------------------------------------------------------------------------
+# Documentation
+#--------------------------------------------------------------------------------
+
+set(ENABLE_DOXYGEN OFF CACHE BOOL "")
+
+set(ENABLE_SPHINX OFF CACHE BOOL "")
+
+#--------------------------------------------------------------------------------
+# Development tools
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# addr2line
+#--------------------------------------------------------------------------------
+
+set(ENABLE_ADDR2LINE ON CACHE BOOL "")
+

--- a/host-configs/LLNL/lvarray-lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1-cuda@11.8.0.cmake
+++ b/host-configs/LLNL/lvarray-lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1-cuda@11.8.0.cmake
@@ -3,7 +3,7 @@
 #################################################################################
 #--------------------------------------------------------------------------------
 # SYS_TYPE: blueos_3_ppc64le_ib_p9
-# Compiler Spec: clang@=10.0.1
+# Compiler Spec: gcc@=8.3.1
 # CMake executable path: /usr/tce/packages/cmake/cmake-3.29.2/bin/cmake
 #--------------------------------------------------------------------------------
 
@@ -11,9 +11,9 @@
 # Compilers
 #--------------------------------------------------------------------------------
 
-set(CMAKE_C_COMPILER "/usr/tce/packages/clang/clang-10.0.1-gcc-8.3.1/bin/clang" CACHE PATH "")
+set(CMAKE_C_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/gcc" CACHE PATH "")
 
-set(CMAKE_CXX_COMPILER "/usr/tce/packages/clang/clang-10.0.1-gcc-8.3.1/bin/clang++" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/tce/packages/gcc/gcc-8.3.1/bin/g++" CACHE PATH "")
 
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG" CACHE STRING "")
 
@@ -49,15 +49,15 @@ set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-ogxmfhtalme6gpcoykptldthjmg4rm4q" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/chai-git.4b9060b18b9bec1167026cfb3132bd540c4bd56b_develop-wqfiegcvs7mcvwfbsfhvlp67dq6pgkmj" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-lsyisibfnsvy4fo3qfc6ohj5l4cheu3g" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/raja-git.1d70abf171474d331f1409908bdf1b1c3fe19222_develop-r4gqy5cs36b365up22noodxozbhox5aa" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-jmbjlbdi44jyb6yjcgpmnvavj7opvgmk" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/umpire-git.1ed0669c57f041baa1f1070693991c3a7a43e7ee_develop-f73tjzjdmo7cbxqe4mp7eehf4o5hyamp" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-v3j74o2uag4ty7xyngak7ogbmvireubt" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/camp-git.ee0a3069a7ae72da8bcea63c06260fad34901d43_main-5zgnrmmdn2pijqefj2onhesyqxzoijm3" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -65,9 +65,9 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-xiwon23mamhn2tkcnqks5crznnqaovjt" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-rw6xo4fv4xn4oapuiypwwn7cz3m73naz" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/adiak-0.4.0-tp3jxzzp7ifbreg2erbvusm34w64jau7/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/adiak-0.4.0-n3yugcwz5o3ggvi2nrwybgmfattinedh/lib/cmake/adiak" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Documentation

--- a/host-configs/LLNL/lvarray-ruby-toss_4_x86_64_ib-clang@14.0.6.cmake
+++ b/host-configs/LLNL/lvarray-ruby-toss_4_x86_64_ib-clang@14.0.6.cmake
@@ -33,15 +33,15 @@ set(ENABLE_CUDA OFF CACHE BOOL "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-thhf2i6gjy3pnvdpgxf63zm2hulvdbwu" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-clang-14_tpls/clang-14.0.6/chai-git.4b9060b18b9bec1167026cfb3132bd540c4bd56b_develop-f4wgpqutnikc45ymbfntdnbwcbpxp6ww" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-7bkwfqjvbwyfg6kwi3qnu5nbwoyu7c5s" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-clang-14_tpls/clang-14.0.6/raja-git.1d70abf171474d331f1409908bdf1b1c3fe19222_develop-dn7yccm4x5q2kz6zl7pinkmtmksf3yoc" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-qc6ke6ra4bw5ieyx2eiitfkzngns6b2n" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-clang-14_tpls/clang-14.0.6/umpire-git.1ed0669c57f041baa1f1070693991c3a7a43e7ee_develop-k6gdhiuktlcu5tfk4vuhzyqhj57ew7it" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-4o6q4kk5tjy3tmlcgpns2w2ss5ibm5x6" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-clang-14_tpls/clang-14.0.6/camp-git.ee0a3069a7ae72da8bcea63c06260fad34901d43_main-e2mec4ypeahwfmjk2ntrbonnjlo6cahm" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -49,9 +49,9 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clan
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-d6jzlhx4ofqairetauzhiw7rcocb3lj5" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-clang-14_tpls/clang-14.0.6/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-d6jzlhx4ofqairetauzhiw7rcocb3lj5" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/adiak-0.4.0-vxgcukydyqrm6ciuxrw4leflputw6r5e/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-clang-14_tpls/clang-14.0.6/adiak-0.4.0-vxgcukydyqrm6ciuxrw4leflputw6r5e/lib/cmake/adiak" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Documentation
@@ -59,7 +59,7 @@ set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/cla
 
 set(SPHINX_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/python/quartz-gcc-python/python/bin/sphinx-build" CACHE PATH "")
 
-set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/doxygen-1.8.20-xj3wmf2ztwfreg3ao4zdjyjlami7lrb4/bin/doxygen" CACHE PATH "")
+set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-clang-14_tpls/clang-14.0.6/doxygen-1.8.20-xj3wmf2ztwfreg3ao4zdjyjlami7lrb4/bin/doxygen" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Development tools

--- a/host-configs/LLNL/lvarray-ruby-toss_4_x86_64_ib-gcc@12.1.1.cmake
+++ b/host-configs/LLNL/lvarray-ruby-toss_4_x86_64_ib-gcc@12.1.1.cmake
@@ -33,15 +33,15 @@ set(ENABLE_CUDA OFF CACHE BOOL "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-iev43uxnll3jsod7jloak5iwmox6owlv" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12_tpls/gcc-12.1.1/chai-git.4b9060b18b9bec1167026cfb3132bd540c4bd56b_develop-uq6ogpe5shfs5s5ifayx27gvzm3n3xcf" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-ikig7gipi7bsuxopxfac7uvrup3kd4rx" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12_tpls/gcc-12.1.1/raja-git.1d70abf171474d331f1409908bdf1b1c3fe19222_develop-37yxlbkfjq4ww4iw46u3a3d52oi6pul4" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-4t7pxjbfakzclltrwpajtryfkntshmwu" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12_tpls/gcc-12.1.1/umpire-git.1ed0669c57f041baa1f1070693991c3a7a43e7ee_develop-tymd742qkyap4m2m3kcnlx4mqnikk4pw" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-fv2sc4dnl7tma5k3wpu5r2tgcinfpz7u" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12_tpls/gcc-12.1.1/camp-git.ee0a3069a7ae72da8bcea63c06260fad34901d43_main-wtxnzy3oakj4hdtuj5vpwpdtymqmyt4s" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -49,9 +49,9 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-bno6d6qyyvivznkozzdh27ljrj3yqbv2" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12_tpls/gcc-12.1.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-bno6d6qyyvivznkozzdh27ljrj3yqbv2" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/adiak-0.4.0-dimwte7ij4naho6hhcqowidlxnespn7e/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12_tpls/gcc-12.1.1/adiak-0.4.0-dimwte7ij4naho6hhcqowidlxnespn7e/lib/cmake/adiak" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Documentation
@@ -59,7 +59,7 @@ set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-1
 
 set(SPHINX_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/python/quartz-gcc-python/python/bin/sphinx-build" CACHE PATH "")
 
-set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/doxygen-1.8.20-hbxmvlkrwmpt5mvibhths6cdo5rlor3s/bin/doxygen" CACHE PATH "")
+set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12_tpls/gcc-12.1.1/doxygen-1.8.20-hbxmvlkrwmpt5mvibhths6cdo5rlor3s/bin/doxygen" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Development tools

--- a/host-configs/LLNL/lvarray-ruby-toss_4_x86_64_ib-gcc@12noAVX.cmake
+++ b/host-configs/LLNL/lvarray-ruby-toss_4_x86_64_ib-gcc@12noAVX.cmake
@@ -35,15 +35,15 @@ set(ENABLE_CUDA OFF CACHE BOOL "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-wtbhnhf2zdlchyvk3xfgwni2wnjxo3js" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12noAVX_tpls/gcc-12noAVX/chai-git.4b9060b18b9bec1167026cfb3132bd540c4bd56b_develop-leifvg5jj3pqsdbt2jvujdotbvjavidq" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-e2mjbgvxgfyunnduvgkuntfkblvmrvjo" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12noAVX_tpls/gcc-12noAVX/raja-git.1d70abf171474d331f1409908bdf1b1c3fe19222_develop-2y47wpygfea35spibzd657rncwjgr3xk" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-ixn6mth7nl44zyt34hztcdnqit6h6aqy" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12noAVX_tpls/gcc-12noAVX/umpire-git.1ed0669c57f041baa1f1070693991c3a7a43e7ee_develop-2fsgks5hmrb5eep4xrcn7cn6tf2s25qt" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-mjbymoc6da5vwtgx7kgfcg6x37ilciyg" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12noAVX_tpls/gcc-12noAVX/camp-git.ee0a3069a7ae72da8bcea63c06260fad34901d43_main-sw3zpyoowyj5f2eo43rnd5sxmdeopmzi" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -51,9 +51,9 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/g
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-olusdj2xpppf5tam6ktcysn6ogeq4i2d" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12noAVX_tpls/gcc-12noAVX/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-olusdj2xpppf5tam6ktcysn6ogeq4i2d" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/adiak-0.4.0-kgrknuu6drw34t7svfcen5t5u37i4jnf/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12noAVX_tpls/gcc-12noAVX/adiak-0.4.0-kgrknuu6drw34t7svfcen5t5u37i4jnf/lib/cmake/adiak" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Documentation
@@ -61,7 +61,7 @@ set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/
 
 set(SPHINX_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/python/quartz-gcc-python/python/bin/sphinx-build" CACHE PATH "")
 
-set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/doxygen-1.8.20-c4zarmc366msdoizvmau2bs7n76ob7vo/bin/doxygen" CACHE PATH "")
+set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-04-03_spack/ruby-gcc-12noAVX_tpls/gcc-12noAVX/doxygen-1.8.20-c4zarmc366msdoizvmau2bs7n76ob7vo/bin/doxygen" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Development tools


### PR DESCRIPTION
This PR:
- Updates the RAJA suite of packages to v2025.03.0

Related to PR's:
GEOS-DEV/GEOS#3613
GEOS-DEV/thirdPartyLibs#303
