### PR TITLE
fix: ignore DS_Store files from macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/doxygen/LvArrayConfig.hpp
 uberenv_libs
 spack-*.txt
 *__pycache__
+**/.DS_Store


### PR DESCRIPTION
Ignoring DS_Store files in all directories.