### PR TITLE
fix behavior of nested arrays

### DIFF
--- a/src/ChaiBuffer.hpp
+++ b/src/ChaiBuffer.hpp
@@ -436,14 +436,7 @@ public:
     if( m_pointerRecord == nullptr ||
         m_capacity == 0 ||
         chaiSpace == chai::NONE ) return;
-
-    chai::ExecutionSpace const prevSpace = m_pointerRecord->m_last_space;
-
-    if( prevSpace == chai::CPU && prevSpace != chaiSpace ) moveInnerData( space, size, touch );
-
-    move( space, touch );
-
-    if( prevSpace == chai::GPU && prevSpace != chaiSpace ) moveInnerData( space, size, touch );
+    moveNestedImpl( space, size, touch );
   #else
     LVARRAY_ERROR_IF_NE( space, MemorySpace::host );
     LVARRAY_UNUSED_VARIABLE( size );
@@ -552,6 +545,24 @@ public:
   }
 
 private:
+
+  template< typename U=T_non_const >
+  std::enable_if_t< bufferManipulation::HasMemberFunction_move< U > >
+  moveNestedImpl( MemorySpace const space, std::ptrdiff_t const size, bool const touch ) const
+  {
+    if( m_pointerRecord->m_last_space != chai::CPU )
+    {
+      move( MemorySpace::host, false );
+    }
+
+    moveInnerData( space, size, touch );
+    move( space, touch );
+  }
+
+  template< typename U=T_non_const >
+  std::enable_if_t< !bufferManipulation::HasMemberFunction_move< U > >
+  moveNestedImpl( MemorySpace const space, std::ptrdiff_t const, bool const touch ) const
+  { move( space, touch ); }
 
   /**
    * @tparam U A dummy parameter to enable SFINAE, do not specify.

--- a/unitTests/testArray1DOfArray1D.cpp
+++ b/unitTests/testArray1DOfArray1D.cpp
@@ -266,6 +266,229 @@ TYPED_TEST( Array1DOfArray1DTest, emptyMove )
   this->emptyMove();
 }
 
+#if defined(LVARRAY_USE_CHAI) && ( defined(LVARRAY_USE_CUDA) || defined(LVARRAY_USE_HIP) )
+
+class Array1DOfArray1DOfArrayView2DTest : public ::testing::Test
+{
+public:
+  using T = double;
+  using IndexType = std::ptrdiff_t;
+
+  template< typename U >
+  using Array1D = Array< U, 1, RAJA::PERM_I, IndexType, ChaiBuffer >;
+
+  template< typename U >
+  using Array2D = Array< U, 2, RAJA::PERM_IJ, IndexType, ChaiBuffer >;
+
+  template< typename U >
+  using ArrayView2D = ArrayView< U, 2, 1, IndexType, ChaiBuffer >;
+
+  using LeafOwners = Array1D< Array1D< Array2D< T > > >;
+  using NestedViews = Array1D< Array1D< ArrayView2D< T const > > >;
+  using NestedViewConst = typename NestedViews::NestedViewTypeConst;
+
+  static constexpr IndexType OUTER_SIZE = 3;
+
+  static constexpr IndexType innerSize( IndexType const i )
+  { return i + 1; }
+
+  static constexpr IndexType numRows( IndexType const i, IndexType const )
+  { return i + 1; }
+
+  static constexpr IndexType numCols( IndexType const, IndexType const j )
+  { return j + 2; }
+
+  static LVARRAY_HOST_DEVICE constexpr T initialValue( IndexType const i,
+                                                       IndexType const j,
+                                                       IndexType const r,
+                                                       IndexType const c )
+  { return T( 1000 * i + 100 * j + 10 * r + c ); }
+
+  static LVARRAY_HOST_DEVICE constexpr T deviceTouchedValue( IndexType const i,
+                                                             IndexType const j,
+                                                             IndexType const r,
+                                                             IndexType const c )
+  { return initialValue( i, j, r, c ) + T( 5000 ); }
+
+  static LVARRAY_HOST_DEVICE constexpr T hostTouchedValue( IndexType const i,
+                                                           IndexType const j,
+                                                           IndexType const r,
+                                                           IndexType const c )
+  { return initialValue( i, j, r, c ) + T( 9000 ); }
+
+  static void initialize( LeafOwners & owners, NestedViews & views )
+  {
+    owners.resize( OUTER_SIZE );
+    views.resize( OUTER_SIZE );
+
+    for( IndexType i = 0; i < OUTER_SIZE; ++i )
+    {
+      owners[ i ].resize( innerSize( i ) );
+      views[ i ].resize( innerSize( i ) );
+
+      for( IndexType j = 0; j < owners[ i ].size(); ++j )
+      {
+        owners[ i ][ j ].resize( numRows( i, j ), numCols( i, j ) );
+
+        for( IndexType r = 0; r < owners[ i ][ j ].size( 0 ); ++r )
+        {
+          for( IndexType c = 0; c < owners[ i ][ j ].size( 1 ); ++c )
+          {
+            owners[ i ][ j ]( r, c ) = initialValue( i, j, r, c );
+          }
+        }
+
+        views[ i ][ j ] = owners[ i ][ j ].toViewConst();
+      }
+    }
+  }
+
+  static void touchLeavesOnDevice( LeafOwners & owners )
+  {
+    for( IndexType i = 0; i < owners.size(); ++i )
+    {
+      for( IndexType j = 0; j < owners[ i ].size(); ++j )
+      {
+        ArrayView2D< T > const leafView = owners[ i ][ j ].toView();
+        forall< parallelDevicePolicy< 32 > >( leafView.size( 0 ), [leafView, i, j] LVARRAY_HOST_DEVICE ( IndexType const r )
+            {
+              for( IndexType c = 0; c < leafView.size( 1 ); ++c )
+              {
+                leafView( r, c ) = deviceTouchedValue( i, j, r, c );
+              }
+            } );
+      }
+    }
+  }
+
+  static void touchLeavesOnHost( LeafOwners & owners )
+  {
+    for( IndexType i = 0; i < owners.size(); ++i )
+    {
+      for( IndexType j = 0; j < owners[ i ].size(); ++j )
+      {
+        ArrayView2D< T > const leafView = owners[ i ][ j ].toView();
+        forall< serialPolicy >( leafView.size( 0 ), [leafView, i, j] LVARRAY_HOST_DEVICE ( IndexType const r )
+            {
+              for( IndexType c = 0; c < leafView.size( 1 ); ++c )
+              {
+                leafView( r, c ) = hostTouchedValue( i, j, r, c );
+              }
+            } );
+      }
+    }
+  }
+
+  static void expectDeviceTouchedValuesInHostKernel( NestedViewConst const & nestedView )
+  {
+    forall< serialPolicy >( nestedView.size(), [nestedView] LVARRAY_HOST_DEVICE ( IndexType const i )
+        {
+          for( IndexType j = 0; j < nestedView[ i ].size(); ++j )
+          {
+            for( IndexType r = 0; r < nestedView[ i ][ j ].size( 0 ); ++r )
+            {
+              for( IndexType c = 0; c < nestedView[ i ][ j ].size( 1 ); ++c )
+              {
+                PORTABLE_EXPECT_EQ( nestedView[ i ][ j ]( r, c ), deviceTouchedValue( i, j, r, c ) );
+              }
+            }
+          }
+        } );
+  }
+
+  static void expectDeviceTouchedValuesOnHost( NestedViewConst const & nestedView )
+  {
+    for( IndexType i = 0; i < nestedView.size(); ++i )
+    {
+      for( IndexType j = 0; j < nestedView[ i ].size(); ++j )
+      {
+        for( IndexType r = 0; r < nestedView[ i ][ j ].size( 0 ); ++r )
+        {
+          for( IndexType c = 0; c < nestedView[ i ][ j ].size( 1 ); ++c )
+          {
+            EXPECT_EQ( nestedView[ i ][ j ]( r, c ), deviceTouchedValue( i, j, r, c ) );
+          }
+        }
+      }
+    }
+  }
+
+  static void warmOuterViewOnDevice( NestedViewConst const & nestedView )
+  {
+    forall< parallelDevicePolicy< 32 > >( nestedView.size(), [nestedView] LVARRAY_HOST_DEVICE ( IndexType const i )
+        {
+          for( IndexType j = 0; j < nestedView[ i ].size(); ++j )
+          {
+            for( IndexType r = 0; r < nestedView[ i ][ j ].size( 0 ); ++r )
+            {
+              for( IndexType c = 0; c < nestedView[ i ][ j ].size( 1 ); ++c )
+              {
+                PORTABLE_EXPECT_EQ( nestedView[ i ][ j ]( r, c ), initialValue( i, j, r, c ) );
+              }
+            }
+          }
+        } );
+  }
+
+  static void expectHostTouchedValuesInDeviceKernel( NestedViewConst const & nestedView )
+  {
+    forall< parallelDevicePolicy< 32 > >( nestedView.size(), [nestedView] LVARRAY_HOST_DEVICE ( IndexType const i )
+        {
+          for( IndexType j = 0; j < nestedView[ i ].size(); ++j )
+          {
+            for( IndexType r = 0; r < nestedView[ i ][ j ].size( 0 ); ++r )
+            {
+              for( IndexType c = 0; c < nestedView[ i ][ j ].size( 1 ); ++c )
+              {
+                PORTABLE_EXPECT_EQ( nestedView[ i ][ j ]( r, c ), hostTouchedValue( i, j, r, c ) );
+              }
+            }
+          }
+        } );
+  }
+};
+
+TEST_F( Array1DOfArray1DOfArrayView2DTest, hostCaptureAfterDeviceTouch )
+{
+  LeafOwners owners;
+  NestedViews views;
+  initialize( owners, views );
+
+  touchLeavesOnDevice( owners );
+
+  NestedViewConst const & nestedViewConst = views.toNestedViewConst();
+  expectDeviceTouchedValuesInHostKernel( nestedViewConst );
+}
+
+TEST_F( Array1DOfArray1DOfArrayView2DTest, explicitHostMoveAfterDeviceTouch )
+{
+  LeafOwners owners;
+  NestedViews views;
+  initialize( owners, views );
+
+  touchLeavesOnDevice( owners );
+
+  NestedViewConst const & nestedViewConst = views.toNestedViewConst();
+  nestedViewConst.move( MemorySpace::host );
+  expectDeviceTouchedValuesOnHost( nestedViewConst );
+}
+
+TEST_F( Array1DOfArray1DOfArrayView2DTest, deviceCaptureAfterHostTouchFollowingDeviceUse )
+{
+  LeafOwners owners;
+  NestedViews views;
+  initialize( owners, views );
+
+  NestedViewConst const & nestedViewConst = views.toNestedViewConst();
+  warmOuterViewOnDevice( nestedViewConst );
+
+  touchLeavesOnHost( owners );
+
+  expectHostTouchedValuesInDeviceKernel( nestedViewConst );
+}
+
+#endif
+
 } // namespace testing
 } // namespace LvArray
 

--- a/unitTests/testUtils.hpp
+++ b/unitTests/testUtils.hpp
@@ -66,8 +66,8 @@ template< unsigned long THREADS_PER_BLOCK >
 using parallelDevicePolicy = RAJA::cuda_exec< THREADS_PER_BLOCK >;
 
 
-template< unsigned long THREADS_PER_BLOCK >
-struct RAJAHelper< RAJA::cuda_exec< THREADS_PER_BLOCK > >
+template< typename X, typename Y, typename C, size_t BLOCK_SIZE, bool ASYNC >
+struct RAJAHelper< RAJA::policy::cuda::cuda_exec_explicit< X, Y, C, BLOCK_SIZE, ASYNC > >
 {
   using ReducePolicy = RAJA::cuda_reduce;
   using AtomicPolicy = RAJA::cuda_atomic;
@@ -80,8 +80,8 @@ template< unsigned long THREADS_PER_BLOCK >
 using parallelDevicePolicy = RAJA::hip_exec< THREADS_PER_BLOCK >;
 
 
-template< unsigned long THREADS_PER_BLOCK >
-struct RAJAHelper< RAJA::hip_exec< THREADS_PER_BLOCK > >
+template< typename X, typename Y, typename C, bool ASYNC >
+struct RAJAHelper< RAJA::policy::hip::hip_exec< X, Y, C, ASYNC > >
 {
   using ReducePolicy = RAJA::hip_reduce;
   using AtomicPolicy = RAJA::hip_atomic;

--- a/unitTests/testUtils.hpp
+++ b/unitTests/testUtils.hpp
@@ -66,12 +66,26 @@ template< unsigned long THREADS_PER_BLOCK >
 using parallelDevicePolicy = RAJA::cuda_exec< THREADS_PER_BLOCK >;
 
 
-template< typename X, typename Y, typename C, size_t BLOCK_SIZE, bool ASYNC >
-struct RAJAHelper< RAJA::policy::cuda::cuda_exec_explicit< X, Y, C, BLOCK_SIZE, ASYNC > >
+template< unsigned long THREADS_PER_BLOCK >
+struct RAJAHelper< RAJA::cuda_exec< THREADS_PER_BLOCK > >
 {
   using ReducePolicy = RAJA::cuda_reduce;
   using AtomicPolicy = RAJA::cuda_atomic;
   static constexpr MemorySpace space = MemorySpace::cuda;
+};
+
+#elif defined(LVARRAY_USE_HIP)
+
+template< unsigned long THREADS_PER_BLOCK >
+using parallelDevicePolicy = RAJA::hip_exec< THREADS_PER_BLOCK >;
+
+
+template< unsigned long THREADS_PER_BLOCK >
+struct RAJAHelper< RAJA::hip_exec< THREADS_PER_BLOCK > >
+{
+  using ReducePolicy = RAJA::hip_reduce;
+  using AtomicPolicy = RAJA::hip_atomic;
+  static constexpr MemorySpace space = MemorySpace::hip;
 };
 
 #endif


### PR DESCRIPTION
this fix addresses an issue observed in the capture and move of data in an `ArrayView< ArrayView< ArrayView > > >`. Certain situations would result in the failure to move the underlying data in the leaf of the nested array. This PR forces the move of the leaf array data regardless of the status of the outer arrays.